### PR TITLE
fix(http): preserve encoded characters in URL query parameters

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Any
 from urllib.parse import urlparse
+from yarl import URL
 import argparse
 import yaml
 
@@ -703,7 +704,7 @@ class UnifiedDownloader:
                 return True
             
             async with aiohttp.ClientSession() as session:
-                async with session.get(url, headers=self.headers) as response:
+                async with session.get(URL(url, encoded=True), headers=self.headers) as response:
                     if response.status == 200:
                         content = await response.read()
                         with open(save_path, 'wb') as f:


### PR DESCRIPTION
部分链接的`x-signature`会出现`/`符号，如：`x-signature=bjZprxC26bv4AE/Q/JRSMUAbgiF`，导致文件无法下载，服务器返回403，使用`Url(url, encoded=True)`将`/`转义成`%2F`可正常完成下载。

初步怀疑 #73 与这个问题有关
