### PR TITLE
修改了下载User Post时创建文件名的逻辑以对Windows适配

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -571,6 +571,7 @@ class UnifiedDownloader:
             desc = desc.strip()[:50]
             desc = re.sub(r'[<>:"/\\|?*\x00-\x1f]', '_', desc)
             desc = desc.strip()
+            desc= desc.rstrip('.')
             # 兼容 create_time 为时间戳或格式化字符串
             raw_create_time = video_info.get('create_time')
             dt_obj = None


### PR DESCRIPTION
Windos不允许文件夹名，文件名中的末尾为空格，原代码会导致没有Tag的视频保存错误Errno2等（没有Tag的视频名末尾会被处理为一个空格），故修改代码并提交。同时修改一个函数以传入config中的日期。