### PR TITLE
fix: prefer image content type for gallery suffixes

### DIFF
--- a/core/downloader_base.py
+++ b/core/downloader_base.py
@@ -322,20 +322,24 @@ class BaseDownloader(ABC):
                 return False
 
             for index, image_url in enumerate(image_urls, start=1):
-                suffix = Path(urlparse(image_url).path).suffix or ".jpg"
+                suffix = self._infer_image_extension(image_url)
                 image_path = save_dir / f"{file_stem}_{index}{suffix}"
-                success = await self._download_with_retry(
+                download_result = await self._download_with_retry(
                     image_url,
                     image_path,
                     session,
                     headers=self._download_headers(),
+                    prefer_response_content_type=True,
+                    return_saved_path=True,
                 )
-                if not success:
+                if not download_result:
                     logger.error(
                         f"Failed downloading image {index} for aweme {aweme_id}"
                     )
                     return False
-                downloaded_files.append(image_path)
+                downloaded_files.append(
+                    download_result if isinstance(download_result, Path) else image_path
+                )
 
             for index, live_url in enumerate(image_live_urls, start=1):
                 suffix = Path(urlparse(live_url).path).suffix or ".mp4"
@@ -437,18 +441,24 @@ class BaseDownloader(ABC):
         *,
         headers: Optional[Dict[str, str]] = None,
         optional: bool = False,
-    ) -> bool:
+        prefer_response_content_type: bool = False,
+        return_saved_path: bool = False,
+    ) -> bool | Path:
         async def _task():
-            success = await self.file_manager.download_file(
-                url, save_path, session, headers=headers
+            download_result = await self.file_manager.download_file(
+                url,
+                save_path,
+                session,
+                headers=headers,
+                prefer_response_content_type=prefer_response_content_type,
+                return_saved_path=return_saved_path,
             )
-            if not success:
+            if not download_result:
                 raise RuntimeError(f"Download failed for {url}")
-            return True
+            return download_result
 
         try:
-            await self.retry_handler.execute_with_retry(_task)
-            return True
+            return await self.retry_handler.execute_with_retry(_task)
         except Exception as error:
             log_fn = logger.warning if optional else logger.error
             self._log_download_error(
@@ -586,6 +596,23 @@ class BaseDownloader(ABC):
         elif isinstance(source, str) and source:
             return source
         return None
+
+    @staticmethod
+    def _infer_image_extension(image_url: str) -> str:
+        allowed_exts = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
+        if not image_url:
+            return ".jpg"
+
+        image_path = (urlparse(image_url).path or "").lower()
+        raw_suffix = Path(image_path).suffix.lower()
+        if raw_suffix in allowed_exts:
+            return raw_suffix
+
+        matches = re.findall(r"\.(?:jpe?g|png|webp|gif)(?=[^a-z0-9]|$)", image_path)
+        if matches:
+            return matches[-1].lower()
+
+        return ".jpg"
 
     @staticmethod
     def _resolve_publish_time(create_time: Any) -> Tuple[Optional[int], str]:

--- a/storage/file_manager.py
+++ b/storage/file_manager.py
@@ -56,7 +56,7 @@ class FileManager:
         *,
         prefer_response_content_type: bool = False,
         return_saved_path: bool = False,
-    ) -> bool | Path:
+    ) -> Union[bool, Path]:
         should_close = False
         if session is None:
             default_headers = headers or {

--- a/storage/file_manager.py
+++ b/storage/file_manager.py
@@ -13,7 +13,7 @@ logger = setup_logger("FileManager")
 class FileManager:
     _IMAGE_CONTENT_TYPE_SUFFIXES = {
         "image/gif": ".gif",
-        "image/jpeg": ".jpeg",
+        "image/jpeg": ".jpg",
         "image/jpg": ".jpg",
         "image/png": ".png",
         "image/webp": ".webp",

--- a/storage/file_manager.py
+++ b/storage/file_manager.py
@@ -11,6 +11,14 @@ logger = setup_logger("FileManager")
 
 
 class FileManager:
+    _IMAGE_CONTENT_TYPE_SUFFIXES = {
+        "image/gif": ".gif",
+        "image/jpeg": ".jpeg",
+        "image/jpg": ".jpg",
+        "image/png": ".png",
+        "image/webp": ".webp",
+    }
+
     def __init__(self, base_path: str = "./Downloaded"):
         self.base_path = Path(base_path)
         self.base_path.mkdir(parents=True, exist_ok=True)
@@ -45,7 +53,10 @@ class FileManager:
         save_path: Path,
         session: aiohttp.ClientSession = None,
         headers: Optional[Dict[str, str]] = None,
-    ) -> bool:
+        *,
+        prefer_response_content_type: bool = False,
+        return_saved_path: bool = False,
+    ) -> bool | Path:
         should_close = False
         if session is None:
             default_headers = headers or {
@@ -57,6 +68,7 @@ class FileManager:
             session = aiohttp.ClientSession(headers=default_headers)
             should_close = True
 
+        final_path = save_path
         tmp_path = save_path.with_suffix(save_path.suffix + ".tmp")
         try:
             async with session.get(
@@ -65,6 +77,12 @@ class FileManager:
                 headers=headers,
             ) as response:
                 if response.status == 200:
+                    final_path = self._resolve_save_path_from_content_type(
+                        save_path,
+                        response.headers,
+                        prefer_response_content_type=prefer_response_content_type,
+                    )
+                    tmp_path = final_path.with_suffix(final_path.suffix + ".tmp")
                     expected_size = response.content_length
                     written = 0
                     async with aiofiles.open(tmp_path, "wb") as f:
@@ -80,22 +98,44 @@ class FileManager:
                         )
                         tmp_path.unlink(missing_ok=True)
                         return False
-                    os.replace(str(tmp_path), str(save_path))
-                    return True
+                    os.replace(str(tmp_path), str(final_path))
+                    return final_path if return_saved_path else True
                 else:
                     logger.debug(
                         "Download failed for %s, status=%s",
-                        save_path.name,
+                        final_path.name,
                         response.status,
                     )
                     return False
         except Exception as e:
-            logger.debug("Download error for %s: %s", save_path.name, e)
+            logger.debug("Download error for %s: %s", final_path.name, e)
             tmp_path.unlink(missing_ok=True)
             return False
         finally:
             if should_close:
                 await session.close()
+
+    @classmethod
+    def _resolve_save_path_from_content_type(
+        cls,
+        save_path: Path,
+        response_headers,
+        *,
+        prefer_response_content_type: bool = False,
+    ) -> Path:
+        if not prefer_response_content_type:
+            return save_path
+
+        content_type = (
+            response_headers.get("Content-Type", "")
+            if response_headers
+            else ""
+        )
+        normalized_type = content_type.split(";", 1)[0].strip().lower()
+        suffix = cls._IMAGE_CONTENT_TYPE_SUFFIXES.get(normalized_type)
+        if not suffix:
+            return save_path
+        return save_path.with_suffix(suffix)
 
     def file_exists(self, file_path: Path) -> bool:
         try:

--- a/tests/test_video_downloader.py
+++ b/tests/test_video_downloader.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from auth import CookieManager
@@ -310,6 +311,137 @@ async def test_download_aweme_assets_gallery_downloads_live_photo_videos(
     assert sum(path.suffix == ".mp4" for path in saved_paths) == 2
     assert any("_live_1.mp4" in path.name for path in saved_paths)
     assert any("_live_2.mp4" in path.name for path in saved_paths)
+
+    await api_client.close()
+
+
+@pytest.mark.asyncio
+async def test_download_aweme_assets_gallery_preserves_real_image_extensions(
+    tmp_path, monkeypatch
+):
+    downloader, api_client = _build_downloader(tmp_path)
+    downloader.config.update(
+        music=False, cover=False, avatar=False, json=False, folderstyle=True
+    )
+
+    async def _fake_get_session():
+        return object()
+
+    monkeypatch.setattr(api_client, "get_session", _fake_get_session)
+
+    saved_paths = []
+
+    async def _fake_download_with_retry(self, _url, save_path, _session, **_kwargs):
+        saved_paths.append(save_path)
+        return True
+
+    downloader._download_with_retry = _fake_download_with_retry.__get__(
+        downloader, VideoDownloader
+    )
+
+    aweme_data = {
+        "aweme_id": "7600224486650121991",
+        "desc": "图集后缀归一化",
+        "image_post_info": {
+            "images": [
+                {
+                    "display_image": {
+                        "url_list": [
+                            "https://example.com/gallery_1.png~tplv-obj.image?x=1"
+                        ]
+                    }
+                },
+                {
+                    "display_image": {
+                        "url_list": [
+                            "https://example.com/gallery_2.jpeg~tplv-resize:1080:0.image"
+                        ]
+                    }
+                },
+                {
+                    "display_image": {
+                        "url_list": ["https://example.com/gallery_3.jpg?from=unit-test"]
+                    }
+                },
+            ]
+        },
+    }
+
+    success = await downloader._download_aweme_assets(
+        aweme_data, author_name="测试作者", mode="post"
+    )
+
+    assert success is True
+    assert [path.suffix for path in saved_paths] == [".png", ".jpeg", ".jpg"]
+
+    await api_client.close()
+
+
+@pytest.mark.asyncio
+async def test_download_aweme_assets_gallery_uses_response_content_type_for_suffix(
+    tmp_path, monkeypatch
+):
+    downloader, api_client = _build_downloader(tmp_path)
+    downloader.config.update(
+        music=False, cover=False, avatar=False, json=False, folderstyle=True
+    )
+
+    content = b"fake png content"
+    publish_ts = 1707303025
+    publish_date = datetime.fromtimestamp(publish_ts).strftime("%Y-%m-%d")
+    aweme_id = "7600224486650121992"
+
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.content_length = len(content)
+    mock_response.headers = {"Content-Type": "image/png; charset=binary"}
+
+    async def iter_chunked(_size):
+        yield content
+
+    mock_response.content = MagicMock()
+    mock_response.content.iter_chunked = iter_chunked
+
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=mock_response)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = MagicMock()
+    mock_session.get.return_value = ctx
+
+    async def _fake_get_session():
+        return mock_session
+
+    monkeypatch.setattr(api_client, "get_session", _fake_get_session)
+
+    aweme_data = {
+        "aweme_id": aweme_id,
+        "desc": "响应头决定后缀",
+        "create_time": publish_ts,
+        "image_post_info": {
+            "images": [
+                {
+                    "display_image": {
+                        "url_list": ["https://example.com/gallery_1.image?x=1"]
+                    }
+                }
+            ]
+        },
+    }
+
+    success = await downloader._download_aweme_assets(
+        aweme_data, author_name="测试作者", mode="post"
+    )
+
+    assert success is True
+    save_dir = tmp_path / "测试作者" / "post" / f"{publish_date}_响应头决定后缀_{aweme_id}"
+    saved_files = sorted(path.name for path in save_dir.iterdir() if path.is_file())
+    assert saved_files == [f"{publish_date}_响应头决定后缀_{aweme_id}_1.png"]
+
+    manifest_path = tmp_path / "download_manifest.jsonl"
+    lines = manifest_path.read_text(encoding="utf-8").strip().splitlines()
+    manifest_entry = json.loads(lines[-1])
+    assert manifest_entry["file_names"] == saved_files
 
     await api_client.close()
 


### PR DESCRIPTION
## Summary
- normalize Douyin gallery image suffixes from transformed URLs like `*.png~tplv-obj.image`
- prefer response `Content-Type` when saving gallery images so final filenames and manifest entries reflect the real image type
- add regression coverage for both URL-based suffix normalization and response-header-based suffix correction

## Test Plan
- [x] `PYTHONPATH=. pytest -q tests/test_video_downloader.py tests/test_file_manager.py`
- [x] `PYTHONPATH=. pytest -q` *(currently still has 2 pre-existing failures in `tests/test_database.py` because `storage/database.py` is missing `import asyncio`)*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes gallery image suffix handling in two complementary ways: (1) `_infer_image_extension` now uses a regex to extract the real image extension from Douyin's transformed URL formats (e.g. `gallery.png~tplv-obj.image`), and (2) `FileManager.download_file` now optionally overrides the inferred extension with the actual `Content-Type` header from the server response, ensuring both saved filenames and manifest entries reflect the true image format.

Key changes and issues found:
- **Logic bug (logging)**: The size-mismatch warning in `file_manager.py` still logs `save_path.name` after `final_path` has been resolved to the content-type-corrected path, producing misleading log output when the extension changes.
- **Behavior concern**: `image/jpeg` is mapped to `.jpeg` rather than the more widely-used `.jpg`, meaning the majority of Douyin JPEG gallery images will now be saved with the less common `.jpeg` extension — a silent rename that could confuse users or break downstream tooling filtering by `.jpg`.
- **Compatibility concern**: Both changed files introduce `bool | Path` as a return type annotation using the `X | Y` union syntax (PEP 604), which requires Python 3.10+. The rest of the codebase uses `Optional[X]` from `typing`, which is compatible with Python 3.5+.
- **Test coverage gap**: The URL-normalization test mocks `_download_with_retry` to return `True` instead of a `Path`, so the `downloaded_files`/manifest recording branch that handles the returned `Path` is not exercised by that test case.

<h3>Confidence Score: 3/5</h3>

- Safe to merge functionally, but has a minor log bug, a potentially confusing `.jpeg` vs `.jpg` extension choice, and a Python version compatibility concern worth confirming.
- The core logic for URL-based suffix normalization and content-type override is correct and well-covered by the second integration test. The issues identified are a stale variable reference in a log warning (not affecting correctness), an opinionated `.jpeg` vs `.jpg` extension mapping, a Python version annotation concern, and a test mock that doesn't fully exercise the returned-path code path.
- `storage/file_manager.py` deserves the most attention: it contains the stale log reference, the `image/jpeg` → `.jpeg` mapping decision, and the `bool | Path` annotation.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| storage/file_manager.py | Adds content-type-based path resolution for gallery downloads; minor issues: size-mismatch warning logs the stale `save_path.name` instead of `final_path.name`, `image/jpeg` maps to `.jpeg` (not `.jpg`), and the `bool | Path` return annotation requires Python 3.10+. |
| core/downloader_base.py | Introduces `_infer_image_extension` for URL-based suffix normalization and threads `prefer_response_content_type`/`return_saved_path` through `_download_with_retry`; logic is correct, but the `bool | Path` annotation requires Python 3.10+. |
| tests/test_video_downloader.py | Adds two regression tests; the URL-normalization test's mock returns `True` instead of a `Path`, so it doesn't exercise the full content-type-override code path in `downloaded_files` and manifest recording. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant AD as _download_aweme_assets
    participant IIE as _infer_image_extension
    participant DWR as _download_with_retry
    participant FM as FileManager.download_file
    participant RSPC as _resolve_save_path_from_content_type
    participant FS as Filesystem

    AD->>IIE: image_url (e.g. gallery_1.png~tplv-obj.image)
    IIE-->>AD: .png (regex-extracted from URL path)
    AD->>DWR: url, image_path (.png), prefer_response_content_type=True, return_saved_path=True
    DWR->>FM: url, save_path (.png), prefer_response_content_type=True, return_saved_path=True
    FM->>FM: GET url → response (200, Content-Type: image/jpeg)
    FM->>RSPC: save_path (.png), response.headers, prefer=True
    RSPC-->>FM: final_path (.jpeg) [image/jpeg → .jpeg]
    FM->>FS: write to final_path.tmp, rename to final_path (.jpeg)
    FM-->>DWR: Path("...gallery_1.jpeg")
    DWR-->>AD: Path("...gallery_1.jpeg")
    AD->>AD: downloaded_files.append(Path("...gallery_1.jpeg"))
    AD->>AD: manifest["file_names"] = ["...gallery_1.jpeg"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `storage/file_manager.py`, line 94-95 ([link](https://github.com/jiji262/douyin-downloader/blob/45eaa6d84ead70d38444ff505dd2f17466c90b3e/storage/file_manager.py#L94-L95)) 

   **Size mismatch log uses stale `save_path.name`**

   After the content-type resolution updates `final_path` (and `tmp_path`) to use the real extension, the size-mismatch warning still references the *original* `save_path.name`. This means the log message will show the wrong filename whenever the Content-Type suffix differs from the one inferred from the URL — making it harder to correlate log warnings with actual files on disk.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 45eaa6d</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->