### PR TITLE
feat: add favorites collection modes and harden downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 中文文档 (Chinese): [README.zh-CN.md](./README.zh-CN.md)
 
-A practical Douyin downloader supporting videos, image-notes, collections, music, and profile batch downloads, with progress display, retries, SQLite deduplication, download integrity checks, and browser fallback support.
+A practical Douyin downloader supporting videos, image-notes, collections, music, favorites collections, and profile batch downloads, with progress display, retries, SQLite deduplication, download integrity checks, and browser fallback support.
 
 > This document targets **V2.0 (`main` branch)**.  
 > For the legacy version, switch to **V1.0**: `git fetch --all && git switch V1.0`
@@ -18,11 +18,12 @@ A practical Douyin downloader supporting videos, image-notes, collections, music
 | Feature | Description |
 |---------|-------------|
 | Single video download | `/video/{aweme_id}` |
-| Single image-note download | `/note/{note_id}` |
+| Single image-note download | `/note/{note_id}` and `/gallery/{note_id}` |
 | Single collection download | `/collection/{mix_id}` and `/mix/{mix_id}` |
 | Single music download | `/music/{music_id}` (prefers direct audio, fallback to first related aweme) |
 | Short link parsing | `https://v.douyin.com/...` |
 | Profile batch download | `/user/{sec_uid}` + `mode: [post, like, mix, music]` |
+| Logged-in favorites collections | `/user/self?showTab=favorite_collection` + `mode: [collect, collectmix]` |
 | No-watermark preferred | Automatically selects watermark-free video source |
 | Extra assets | Cover, music, avatar, JSON metadata |
 | Video transcription | Optional, using OpenAI Transcriptions API |
@@ -42,6 +43,9 @@ A practical Douyin downloader supporting videos, image-notes, collections, music
 
 - Browser fallback is fully validated for `post`; `like/mix/music` currently relies on API pagination
 - `number.allmix` / `increase.allmix` are retained as compatibility aliases and normalized to `mix`
+- `collect` / `collectmix` currently work for the account represented by the logged-in cookies only
+- `collect` / `collectmix` must be used alone and cannot be combined with `post` / `like` / `mix` / `music`
+- `increase` currently applies to `post` / `like` / `mix` / `music`; favorites collection modes do not support incremental stop
 
 ## Quick Start
 
@@ -96,10 +100,14 @@ mode:
 
 number:
   post: 0
+  collect: 0
+  collectmix: 0
 
 thread: 5
 retry_times: 3
+proxy: ""
 database: true
+database_path: dy_downloader.db
 
 progress:
   quiet_logs: true
@@ -223,6 +231,28 @@ mode:
 
 Cross-mode deduplication: the same aweme_id won't be downloaded twice across different modes.
 
+### Download logged-in favorites collection items
+
+```yaml
+link:
+  - https://www.douyin.com/user/self?showTab=favorite_collection
+mode:
+  - collect
+number:
+  collect: 0
+```
+
+### Download logged-in collected mixes
+
+```yaml
+link:
+  - https://www.douyin.com/user/self?showTab=favorite_collection
+mode:
+  - collectmix
+number:
+  collectmix: 0
+```
+
 ### Incremental download (only new items)
 
 ```yaml
@@ -271,46 +301,68 @@ When enabled, it generates:
 
 If `database: true`, job status is also recorded in SQLite table `transcript_job` (`success/failed/skipped`).
 
+## Testing
+
+Recommended:
+
+```bash
+python3 -m pytest -q
+```
+
+Plain `pytest` is also supported now:
+
+```bash
+pytest -q
+```
+
 ## Key Config Fields
 
 | Field | Description |
 |-------|-------------|
-| `mode` | Supports `post`/`like`/`mix`/`music`, can be combined |
-| `number.post/like/mix/music` | Per-mode download limit, 0 = unlimited |
+| `mode` | Supports `post`/`like`/`mix`/`music`; logged-in favorites mode additionally supports standalone `collect`/`collectmix` |
+| `number.post/like/mix/music/collect/collectmix` | Per-mode download limit, 0 = unlimited |
 | `increase.post/like/mix/music` | Per-mode incremental toggle |
 | `start_time` / `end_time` | Time filter (format: `YYYY-MM-DD`) |
 | `folderstyle` | Create per-item subdirectories |
 | `browser_fallback.*` | Browser fallback for `post` when pagination is restricted |
 | `progress.quiet_logs` | Quiet logs during progress stage |
 | `transcript.*` | Optional transcription after video download |
+| `proxy` | HTTP/HTTPS proxy for API requests and media downloads, e.g. `http://127.0.0.1:7890` |
 | `database` | Enable SQLite deduplication and history |
+| `database_path` | SQLite path, default is `dy_downloader.db` in the current working directory |
 | `thread` | Concurrent download count |
 | `retry_times` | Retry count on failure |
 
 ## Output Structure
 
-Default with `folderstyle: true`:
+Default with `folderstyle: true` and `database_path: dy_downloader.db`:
 
 ```text
-Downloaded/
-├── download_manifest.jsonl
-├── dy_downloader.db          # when database: true
-└── AuthorName/
-    ├── post/
-    │   └── 2024-02-07_Title_aweme_id/
-    │       ├── ...mp4
-    │       ├── ..._cover.jpg
-    │       ├── ..._music.mp3
-    │       ├── ..._data.json
-    │       ├── ..._avatar.jpg
-    │       ├── ...transcript.txt
-    │       └── ...transcript.json
-    ├── like/
-    │   └── ...
-    ├── mix/
-    │   └── ...
-    └── music/
-        └── ...
+workspace/
+├── config.yml
+├── dy_downloader.db          # default location when database: true
+└── Downloaded/
+    ├── download_manifest.jsonl
+    └── AuthorName/
+        ├── post/
+        │   └── 2024-02-07_Title_aweme_id/
+        │       ├── ...mp4
+        │       ├── ..._cover.jpg
+        │       ├── ..._music.mp3
+        │       ├── ..._data.json
+        │       ├── ..._avatar.jpg
+        │       ├── ...transcript.txt
+        │       └── ...transcript.json
+        ├── like/
+        │   └── ...
+        ├── mix/
+        │   └── ...
+        ├── music/
+        │   └── ...
+        ├── collect/
+        │   └── ...
+        └── collectmix/
+            └── ...
 ```
 
 ## Re-downloading Content

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
   <img src="https://socialify.git.ci/jiji262/douyin-downloader/image?custom_description=%E6%8A%96%E9%9F%B3%E6%89%B9%E9%87%8F%E4%B8%8B%E8%BD%BD%E5%B7%A5%E5%85%B7%EF%BC%8C%E5%8E%BB%E6%B0%B4%E5%8D%B0%EF%BC%8C%E6%94%AF%E6%8C%81%E8%A7%86%E9%A2%91%E3%80%81%E5%9B%BE%E9%9B%86%E3%80%81%E4%BD%9C%E8%80%85%E4%B8%BB%E9%A1%B5%E6%89%B9%E9%87%8F%E4%B8%8B%E8%BD%BD%E3%80%82&description=1&font=Jost&forks=1&logo=https%3A%2F%2Fraw.githubusercontent.com%2Fjiji262%2Fdouyin-downloader%2Frefs%2Fheads%2FV1.0%2Fimg%2Flogo.png&name=1&owner=1&pattern=Circuit+Board&pulls=1&stargazers=1&theme=Light" alt="douyin-downloader" width="820" />
 </p>
 
-一个面向实用场景的抖音下载工具，支持视频、图文、合集、音乐等多种类型下载，以及作者主页批量下载，默认带进度展示、重试、数据库去重、下载完整性校验和浏览器兜底能力。
+一个面向实用场景的抖音下载工具，支持视频、图文、合集、音乐、收藏夹等多种类型下载，以及作者主页批量下载，默认带进度展示、重试、数据库去重、下载完整性校验和浏览器兜底能力。
 
 > 当前文档对应 **V2.0（main 分支）**。  
 > 如需使用旧版，请切回 **V1.0**：`git fetch --all && git switch V1.0`
@@ -16,11 +16,12 @@
 | 功能 | 说明 |
 |------|------|
 | 单个视频下载 | `/video/{aweme_id}` |
-| 单个图文下载 | `/note/{note_id}` |
+| 单个图文下载 | `/note/{note_id}`、`/gallery/{note_id}` |
 | 单个合集下载 | `/collection/{mix_id}`、`/mix/{mix_id}` |
 | 单个音乐下载 | `/music/{music_id}`（优先原声文件，缺失时回退到该音乐下首条作品） |
 | 短链自动解析 | `https://v.douyin.com/...` |
 | 用户主页批量下载 | `/user/{sec_uid}` + `mode: [post, like, mix, music]` |
+| 当前登录账号收藏夹下载 | `/user/self?showTab=favorite_collection` + `mode: [collect, collectmix]` |
 | 无水印优先 | 自动选择无水印视频源 |
 | 附加资源下载 | 封面、音乐、头像、JSON 元数据 |
 | 视频转写 | 可选功能，调用 OpenAI Transcriptions API |
@@ -40,6 +41,9 @@
 
 - 浏览器兜底当前仅针对 `post` 完整验证，`like/mix/music` 主要依赖 API 正常分页
 - `number.allmix` / `increase.allmix` 作为兼容别名保留，运行时会归一化到 `mix`
+- `collect` / `collectmix` 当前仅支持当前已登录 Cookie 对应账号
+- `collect` / `collectmix` 必须单独使用，不能和 `post` / `like` / `mix` / `music` 混用
+- `increase` 当前仅支持 `post` / `like` / `mix` / `music`；收藏夹模式不支持增量截断
 
 ## 快速开始
 
@@ -94,10 +98,14 @@ mode:
 
 number:
   post: 0
+  collect: 0
+  collectmix: 0
 
 thread: 5
 retry_times: 3
+proxy: ""
 database: true
+database_path: dy_downloader.db
 
 progress:
   quiet_logs: true
@@ -221,6 +229,28 @@ mode:
 
 跨模式自动去重：同一个 aweme_id 在不同模式下不会重复下载。
 
+### 批量下载当前登录账号收藏夹作品
+
+```yaml
+link:
+  - https://www.douyin.com/user/self?showTab=favorite_collection
+mode:
+  - collect
+number:
+  collect: 0
+```
+
+### 批量下载当前登录账号收藏合集
+
+```yaml
+link:
+  - https://www.douyin.com/user/self?showTab=favorite_collection
+mode:
+  - collectmix
+number:
+  collectmix: 0
+```
+
 ### 增量下载（只下载新作品）
 
 ```yaml
@@ -269,46 +299,68 @@ export OPENAI_API_KEY="sk-xxxx"
 
 若 `database: true`，会在数据库 `transcript_job` 表记录状态（`success/failed/skipped`）。
 
+## 测试
+
+推荐使用：
+
+```bash
+python3 -m pytest -q
+```
+
+当前也支持直接运行：
+
+```bash
+pytest -q
+```
+
 ## 关键配置项
 
 | 配置项 | 说明 |
 |--------|------|
-| `mode` | 支持 `post`/`like`/`mix`/`music`，可组合 |
-| `number.post/like/mix/music` | 各模式下载数量限制，0 为不限 |
+| `mode` | 支持 `post`/`like`/`mix`/`music`；当前登录收藏夹模式额外支持单独使用的 `collect`/`collectmix` |
+| `number.post/like/mix/music/collect/collectmix` | 各模式下载数量限制，0 为不限 |
 | `increase.post/like/mix/music` | 各模式增量开关 |
 | `start_time` / `end_time` | 时间过滤（格式 `YYYY-MM-DD`） |
 | `folderstyle` | 按作品维度创建子目录 |
 | `browser_fallback.*` | `post` 翻页受限时启用浏览器兜底 |
 | `progress.quiet_logs` | 进度阶段静默日志，减少刷屏 |
 | `transcript.*` | 视频下载后的可选转写 |
+| `proxy` | 为 API 请求和媒体下载设置 HTTP/HTTPS 代理，例如 `http://127.0.0.1:7890` |
 | `database` | 启用 SQLite 去重和历史记录 |
+| `database_path` | SQLite 文件路径，默认在当前工作目录生成 `dy_downloader.db` |
 | `thread` | 并发下载数 |
 | `retry_times` | 失败重试次数 |
 
 ## 输出目录
 
-默认 `folderstyle: true` 时：
+默认 `folderstyle: true` 且 `database_path: dy_downloader.db` 时：
 
 ```text
-Downloaded/
-├── download_manifest.jsonl
-├── dy_downloader.db          # database: true 时生成
-└── 作者名/
-    ├── post/
-    │   └── 2024-02-07_作品标题_aweme_id/
-    │       ├── ...mp4
-    │       ├── ..._cover.jpg
-    │       ├── ..._music.mp3
-    │       ├── ..._data.json
-    │       ├── ..._avatar.jpg
-    │       ├── ...transcript.txt
-    │       └── ...transcript.json
-    ├── like/
-    │   └── ...
-    ├── mix/
-    │   └── ...
-    └── music/
-        └── ...
+工作目录/
+├── config.yml
+├── dy_downloader.db          # database: true 时默认生成在这里
+└── Downloaded/
+    ├── download_manifest.jsonl
+    └── 作者名/
+        ├── post/
+        │   └── 2024-02-07_作品标题_aweme_id/
+        │       ├── ...mp4
+        │       ├── ..._cover.jpg
+        │       ├── ..._music.mp3
+        │       ├── ..._data.json
+        │       ├── ..._avatar.jpg
+        │       ├── ...transcript.txt
+        │       └── ...transcript.json
+        ├── like/
+        │   └── ...
+        ├── mix/
+        │   └── ...
+        ├── music/
+        │   └── ...
+        ├── collect/
+        │   └── ...
+        └── collectmix/
+            └── ...
 ```
 
 ## 重新下载

--- a/cli/main.py
+++ b/cli/main.py
@@ -44,7 +44,10 @@ async def download_url(
 
     original_url = url
 
-    async with DouyinAPIClient(cookie_manager.get_cookies()) as api_client:
+    async with DouyinAPIClient(
+        cookie_manager.get_cookies(),
+        proxy=config.get("proxy"),
+    ) as api_client:
         if progress_reporter:
             progress_reporter.advance_step("解析链接", "检查短链并解析 URL")
         if url.startswith('https://v.douyin.com'):

--- a/config.example.yml
+++ b/config.example.yml
@@ -22,6 +22,8 @@ number:
   allmix: 0
   mix: 0
   music: 0
+  collect: 0
+  collectmix: 0
 
 increase:
   post: false
@@ -32,7 +34,9 @@ increase:
 
 thread: 5
 retry_times: 3
+proxy: ""
 database: true
+database_path: dy_downloader.db
 
 progress:
   quiet_logs: true

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -63,6 +63,8 @@ class ConfigLoader:
                     "Invalid DOUYIN_THREAD value: %s, ignoring",
                     os.getenv("DOUYIN_THREAD"),
                 )
+        if os.getenv("DOUYIN_PROXY"):
+            env_config["proxy"] = os.getenv("DOUYIN_PROXY")
         return env_config
 
     def _normalize_mix_aliases(

--- a/config/default_config.py
+++ b/config/default_config.py
@@ -16,6 +16,8 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "allmix": 0,
         "mix": 0,
         "music": 0,
+        "collect": 0,
+        "collectmix": 0,
     },
     "increase": {
         "post": False,
@@ -27,6 +29,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "thread": 5,
     "retry_times": 3,
     "rate_limit": 2,
+    "proxy": "",
     "database": True,
     "database_path": "dy_downloader.db",
     "progress": {

--- a/core/api_client.py
+++ b/core/api_client.py
@@ -60,8 +60,9 @@ class DouyinAPIClient:
         "login_time",
     }
 
-    def __init__(self, cookies: Dict[str, str]):
+    def __init__(self, cookies: Dict[str, str], proxy: Optional[str] = None):
         self.cookies = sanitize_cookies(cookies or {})
+        self.proxy = str(proxy or "").strip()
         self._session: Optional[aiohttp.ClientSession] = None
         self._browser_post_aweme_items: Dict[str, Dict[str, Any]] = {}
         self._browser_post_stats: Dict[str, int] = {}
@@ -195,6 +196,7 @@ class DouyinAPIClient:
                 async with self._session.get(
                     signed_url,
                     headers={**self.headers, "User-Agent": ua},
+                    proxy=self.proxy or None,
                 ) as response:
                     if response.status == 200:
                         data = await response.json(content_type=None)
@@ -359,6 +361,54 @@ class DouyinAPIClient:
         raw = await self._request_json("/aweme/v1/web/music/list/", params)
         return self._normalize_paged_response(raw, item_keys=["music_list"])
 
+    async def _build_collect_page_params(
+        self, max_cursor: int, count: int
+    ) -> Dict[str, Any]:
+        params = await self._default_query()
+        params.update(
+            {
+                "cursor": max_cursor,
+                "count": count,
+                "version_code": "170400",
+                "version_name": "17.4.0",
+            }
+        )
+        return params
+
+    async def get_user_collects(
+        self, sec_uid: str, max_cursor: int = 0, count: int = 10
+    ) -> Dict[str, Any]:
+        if sec_uid and sec_uid != "self":
+            logger.warning("Collect folders currently require self sec_uid, got=%s", sec_uid)
+            return self._normalize_paged_response(
+                {}, item_keys=["collects_list"], source="api"
+            )
+
+        params = await self._build_collect_page_params(max_cursor, count)
+        raw = await self._request_json("/aweme/v1/web/collects/list/", params)
+        return self._normalize_paged_response(raw, item_keys=["collects_list"])
+
+    async def get_collect_aweme(
+        self, collects_id: str, max_cursor: int = 0, count: int = 10
+    ) -> Dict[str, Any]:
+        params = await self._build_collect_page_params(max_cursor, count)
+        params.update({"collects_id": collects_id})
+        raw = await self._request_json("/aweme/v1/web/collects/video/list/", params)
+        return self._normalize_paged_response(raw, item_keys=["aweme_list"])
+
+    async def get_user_collect_mix(
+        self, sec_uid: str, max_cursor: int = 0, count: int = 12
+    ) -> Dict[str, Any]:
+        if sec_uid and sec_uid != "self":
+            logger.warning("Collect mix currently require self sec_uid, got=%s", sec_uid)
+            return self._normalize_paged_response(
+                {}, item_keys=["mix_infos"], source="api"
+            )
+
+        params = await self._build_collect_page_params(max_cursor, count)
+        raw = await self._request_json("/aweme/v1/web/mix/listcollection/", params)
+        return self._normalize_paged_response(raw, item_keys=["mix_infos"])
+
     async def get_user_info(self, sec_uid: str) -> Optional[Dict[str, Any]]:
         params = await self._default_query()
         params.update({"sec_user_id": sec_uid})
@@ -403,7 +453,11 @@ class DouyinAPIClient:
     async def resolve_short_url(self, short_url: str) -> Optional[str]:
         try:
             await self._ensure_session()
-            async with self._session.get(short_url, allow_redirects=True) as response:
+            async with self._session.get(
+                short_url,
+                allow_redirects=True,
+                proxy=self.proxy or None,
+            ) as response:
                 return str(response.url)
         except Exception as e:
             logger.error("Failed to resolve short URL: %s, error: %s", short_url, e)

--- a/core/downloader_base.py
+++ b/core/downloader_base.py
@@ -440,7 +440,11 @@ class BaseDownloader(ABC):
     ) -> bool:
         async def _task():
             success = await self.file_manager.download_file(
-                url, save_path, session, headers=headers
+                url,
+                save_path,
+                session,
+                headers=headers,
+                proxy=getattr(self.api_client, "proxy", None),
             )
             if not success:
                 raise RuntimeError(f"Download failed for {url}")

--- a/core/url_parser.py
+++ b/core/url_parser.py
@@ -77,7 +77,7 @@ class URLParser:
 
     @staticmethod
     def _extract_note_id(url: str) -> Optional[str]:
-        match = re.search(r'/note/(\d+)', url)
+        match = re.search(r'/(?:note|gallery)/(\d+)', url)
         if match:
             return match.group(1)
         return None

--- a/core/user_downloader.py
+++ b/core/user_downloader.py
@@ -10,6 +10,8 @@ logger = setup_logger("UserDownloader")
 
 
 class UserDownloader(BaseDownloader):
+    SELF_COLLECT_MODES = {"collect", "collectmix"}
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.mode_registry = UserModeRegistry()
@@ -23,12 +25,6 @@ class UserDownloader(BaseDownloader):
             logger.error("No sec_uid found in parsed URL")
             return result
 
-        self._progress_update_step("获取作者信息", f"sec_uid={sec_uid}")
-        user_info = await self.api_client.get_user_info(sec_uid)
-        if not user_info:
-            logger.error("Failed to get user info: %s", sec_uid)
-            return result
-
         modes_config = self.config.get("mode", ["post"])
         if isinstance(modes_config, str):
             modes = [modes_config]
@@ -36,6 +32,14 @@ class UserDownloader(BaseDownloader):
             modes = [str(mode).strip() for mode in modes_config if str(mode).strip()]
         else:
             modes = ["post"]
+
+        if not self._validate_mode_scope(sec_uid, modes):
+            return result
+
+        user_info = await self._resolve_user_info(sec_uid, modes)
+        if not user_info:
+            logger.error("Failed to get user info: %s", sec_uid)
+            return result
 
         self._progress_update_step("下载模式", f"模式: {', '.join(modes)}")
 
@@ -56,6 +60,38 @@ class UserDownloader(BaseDownloader):
             result.skipped += mode_result.skipped
 
         return result
+
+    def _validate_mode_scope(self, sec_uid: str, modes: List[str]) -> bool:
+        normalized_modes = {str(mode or "").strip() for mode in modes}
+        has_collect_mode = bool(normalized_modes & self.SELF_COLLECT_MODES)
+        has_regular_mode = bool(normalized_modes - self.SELF_COLLECT_MODES)
+
+        if has_collect_mode and sec_uid != "self":
+            logger.error(
+                "Modes collect/collectmix only support /user/self?showTab=favorite_collection"
+            )
+            return False
+        if has_collect_mode and has_regular_mode:
+            logger.error(
+                "Modes collect/collectmix cannot be combined with post/like/mix/music"
+            )
+            return False
+        return True
+
+    async def _resolve_user_info(
+        self, sec_uid: str, modes: List[str]
+    ) -> Optional[Dict[str, Any]]:
+        normalized_modes = {str(mode or "").strip() for mode in modes}
+        if sec_uid == "self" and normalized_modes.issubset(self.SELF_COLLECT_MODES):
+            self._progress_update_step("获取作者信息", "使用当前登录账号收藏夹上下文")
+            return {
+                "uid": "self",
+                "sec_uid": "self",
+                "nickname": "self",
+            }
+
+        self._progress_update_step("获取作者信息", f"sec_uid={sec_uid}")
+        return await self.api_client.get_user_info(sec_uid)
 
     def _get_mode_strategy(self, mode: str):
         normalized_mode = (mode or "").strip()

--- a/core/user_mode_registry.py
+++ b/core/user_mode_registry.py
@@ -4,6 +4,8 @@ from typing import Dict, Optional, Type
 
 from core.user_modes import (
     BaseUserModeStrategy,
+    CollectMixUserModeStrategy,
+    CollectUserModeStrategy,
     LikeUserModeStrategy,
     MixUserModeStrategy,
     MusicUserModeStrategy,
@@ -18,6 +20,8 @@ class UserModeRegistry:
             "like": LikeUserModeStrategy,
             "mix": MixUserModeStrategy,
             "music": MusicUserModeStrategy,
+            "collect": CollectUserModeStrategy,
+            "collectmix": CollectMixUserModeStrategy,
         }
 
     def get(self, mode: str) -> Optional[Type[BaseUserModeStrategy]]:

--- a/core/user_modes/__init__.py
+++ b/core/user_modes/__init__.py
@@ -1,4 +1,6 @@
 from .base_strategy import BaseUserModeStrategy
+from .collect_mix_strategy import CollectMixUserModeStrategy
+from .collect_strategy import CollectUserModeStrategy
 from .post_strategy import PostUserModeStrategy
 from .like_strategy import LikeUserModeStrategy
 from .mix_strategy import MixUserModeStrategy
@@ -6,6 +8,8 @@ from .music_strategy import MusicUserModeStrategy
 
 __all__ = [
     "BaseUserModeStrategy",
+    "CollectMixUserModeStrategy",
+    "CollectUserModeStrategy",
     "PostUserModeStrategy",
     "LikeUserModeStrategy",
     "MixUserModeStrategy",

--- a/core/user_modes/base_strategy.py
+++ b/core/user_modes/base_strategy.py
@@ -115,6 +115,38 @@ class BaseUserModeStrategy(ABC):
             return [item for item in items if isinstance(item, dict)]
         return []
 
+    async def _collect_paged_entries(
+        self,
+        fetcher,
+        *fetch_args: Any,
+        count: int = 20,
+    ) -> List[Dict[str, Any]]:
+        entries: List[Dict[str, Any]] = []
+        max_cursor = 0
+        has_more = True
+
+        while has_more:
+            await self.downloader.rate_limiter.acquire()
+            request_cursor = max_cursor
+            page_data = await fetcher(*fetch_args, request_cursor, count)
+            page = self._normalize_page_data(page_data)
+            page_items = self.select_items(page)
+            if not page_items:
+                break
+
+            entries.extend(page_items)
+            has_more = bool(page.get("has_more", False))
+            max_cursor = int(page.get("max_cursor", 0) or 0)
+            if has_more and max_cursor == request_cursor:
+                logger.warning(
+                    "Mode %s cursor did not advance (%s), stop paging",
+                    self.mode_name,
+                    max_cursor,
+                )
+                break
+
+        return entries
+
     async def _expand_metadata_items(
         self,
         raw_items: List[Dict[str, Any]],

--- a/core/user_modes/collect_mix_strategy.py
+++ b/core/user_modes/collect_mix_strategy.py
@@ -21,20 +21,38 @@ class CollectMixUserModeStrategy(BaseUserModeStrategy):
             return []
 
         raw_items = await self._collect_paged_entries(fetch_collect_mix, sec_uid)
-        aweme_items = [
-            a for item in raw_items
-            if (a := self._extract_aweme_from_item(item)) is not None
-        ]
-        if aweme_items:
+        aweme_items: List[Dict[str, Any]] = []
+        metadata_items: List[Dict[str, Any]] = []
+
+        for item in raw_items:
+            aweme = self._extract_aweme_from_item(item)
+            if aweme is not None:
+                aweme_items.append(aweme)
+                continue
+            metadata_items.append(self._normalize_mix_item(item))
+
+        if not metadata_items:
             return aweme_items
 
-        normalized_mix_items = [self._normalize_mix_item(item) for item in raw_items]
-        return await self._expand_metadata_items(
-            normalized_mix_items,
+        expanded_items = await self._expand_metadata_items(
+            metadata_items,
             id_field="mix_id",
             id_aliases=["mixId"],
             fetch_method_name="get_mix_aweme",
         )
+        if not aweme_items:
+            return expanded_items
+
+        merged_items: List[Dict[str, Any]] = []
+        seen_aweme_ids: set[str] = set()
+        for item in aweme_items + expanded_items:
+            aweme_id = str(item.get("aweme_id") or "")
+            if not aweme_id or aweme_id in seen_aweme_ids:
+                continue
+            seen_aweme_ids.add(aweme_id)
+            merged_items.append(item)
+
+        return merged_items
 
     @staticmethod
     def _normalize_mix_item(item: Any) -> Dict[str, Any]:

--- a/core/user_modes/collect_mix_strategy.py
+++ b/core/user_modes/collect_mix_strategy.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from core.user_modes.base_strategy import BaseUserModeStrategy
+from utils.logger import setup_logger
+
+logger = setup_logger("CollectMixUserModeStrategy")
+
+
+class CollectMixUserModeStrategy(BaseUserModeStrategy):
+    mode_name = "collectmix"
+    api_method_name = "get_user_collect_mix"
+
+    async def collect_items(
+        self, sec_uid: str, user_info: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
+        fetch_collect_mix = getattr(self.downloader.api_client, self.api_method_name, None)
+        if not callable(fetch_collect_mix):
+            logger.warning("API client missing %s", self.api_method_name)
+            return []
+
+        raw_items = await self._collect_paged_entries(fetch_collect_mix, sec_uid)
+        aweme_items = [
+            a for item in raw_items
+            if (a := self._extract_aweme_from_item(item)) is not None
+        ]
+        if aweme_items:
+            return aweme_items
+
+        normalized_mix_items = [self._normalize_mix_item(item) for item in raw_items]
+        return await self._expand_metadata_items(
+            normalized_mix_items,
+            id_field="mix_id",
+            id_aliases=["mixId"],
+            fetch_method_name="get_mix_aweme",
+        )
+
+    @staticmethod
+    def _normalize_mix_item(item: Any) -> Dict[str, Any]:
+        if not isinstance(item, dict):
+            return {}
+        if item.get("mix_id") or item.get("mixId"):
+            return item
+        mix_info = item.get("mix_info")
+        if isinstance(mix_info, dict):
+            return {
+                **item,
+                "mix_id": mix_info.get("mix_id") or mix_info.get("id"),
+            }
+        return item

--- a/core/user_modes/collect_strategy.py
+++ b/core/user_modes/collect_strategy.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from core.user_modes.base_strategy import BaseUserModeStrategy
+from utils.logger import setup_logger
+
+logger = setup_logger("CollectUserModeStrategy")
+
+
+class CollectUserModeStrategy(BaseUserModeStrategy):
+    mode_name = "collect"
+    api_method_name = "get_user_collects"
+
+    async def collect_items(
+        self, sec_uid: str, user_info: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
+        fetch_collect_aweme = getattr(self.downloader.api_client, "get_collect_aweme", None)
+        fetch_collects = getattr(self.downloader.api_client, self.api_method_name, None)
+        if not callable(fetch_collects):
+            logger.warning("API client missing %s", self.api_method_name)
+            return []
+        if not callable(fetch_collect_aweme):
+            logger.warning("API client missing get_collect_aweme")
+            return []
+
+        raw_collects = await self._collect_paged_entries(fetch_collects, sec_uid)
+        expanded: List[Dict[str, Any]] = []
+        seen_aweme: set[str] = set()
+
+        for collect_item in raw_collects:
+            collects_id = self._extract_collects_id(collect_item)
+            if not collects_id:
+                continue
+
+            cursor = 0
+            has_more = True
+            while has_more:
+                await self.downloader.rate_limiter.acquire()
+                page_data = await fetch_collect_aweme(
+                    str(collects_id), max_cursor=cursor, count=20
+                )
+                page = self._normalize_page_data(page_data)
+                page_items = page.get("items", [])
+                if not page_items:
+                    break
+
+                for item in page_items:
+                    aweme = self._extract_aweme_from_item(item)
+                    if not aweme:
+                        continue
+                    aweme_id = str(aweme.get("aweme_id") or "")
+                    if not aweme_id or aweme_id in seen_aweme:
+                        continue
+                    seen_aweme.add(aweme_id)
+                    expanded.append(aweme)
+
+                has_more = bool(page.get("has_more", False))
+                next_cursor = int(page.get("max_cursor", 0) or 0)
+                if has_more and next_cursor == cursor:
+                    logger.warning(
+                        "Collect folder %s cursor did not advance", collects_id
+                    )
+                    break
+                cursor = next_cursor
+
+        return expanded
+
+    @staticmethod
+    def _extract_collects_id(item: Any) -> str:
+        if not isinstance(item, dict):
+            return ""
+        return str(
+            item.get("collects_id")
+            or item.get("collects_id_str")
+            or item.get("id")
+            or ((item.get("collects_info") or {}).get("collects_id"))
+            or ((item.get("collects_info") or {}).get("collects_id_str"))
+            or ""
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ include = ["cli*", "core*", "auth*", "config*", "control*", "storage*", "utils*"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+pythonpath = ["."]
 testpaths = ["tests"]
 
 [tool.ruff]

--- a/storage/database.py
+++ b/storage/database.py
@@ -1,3 +1,4 @@
+import asyncio
 import aiosqlite
 from typing import Dict, Any, Optional
 from datetime import datetime
@@ -8,10 +9,11 @@ class Database:
         self.db_path = db_path
         self._initialized = False
         self._conn: Optional[aiosqlite.Connection] = None
+        self._conn_lock = asyncio.Lock()
 
     async def _get_conn(self) -> aiosqlite.Connection:
         if self._conn is None:
-            async with asyncio.Lock():
+            async with self._conn_lock:
                 if self._conn is None:
                     self._conn = await aiosqlite.connect(self.db_path)
         return self._conn

--- a/storage/file_manager.py
+++ b/storage/file_manager.py
@@ -45,6 +45,7 @@ class FileManager:
         save_path: Path,
         session: aiohttp.ClientSession = None,
         headers: Optional[Dict[str, str]] = None,
+        proxy: Optional[str] = None,
     ) -> bool:
         should_close = False
         if session is None:
@@ -63,6 +64,7 @@ class FileManager:
                 url,
                 timeout=aiohttp.ClientTimeout(total=300),
                 headers=headers,
+                proxy=proxy or None,
             ) as response:
                 if response.status == 200:
                     expected_size = response.content_length

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -225,6 +225,63 @@ async def test_user_mode_endpoints_use_shared_paged_normalization(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_collect_endpoints_use_expected_paths_and_normalization(monkeypatch):
+    client = DouyinAPIClient({"msToken": "token-1"})
+    called_requests = []
+
+    async def _fake_request_json(path, params, suppress_error=False):
+        called_requests.append((path, dict(params)))
+        if path == "/aweme/v1/web/collects/list/":
+            return {
+                "status_code": 0,
+                "collects_list": [{"collects_id_str": "collect-1"}],
+                "has_more": 1,
+                "cursor": 9,
+            }
+        if path == "/aweme/v1/web/collects/video/list/":
+            return {
+                "status_code": 0,
+                "aweme_list": [{"aweme_id": "aweme-1"}],
+                "has_more": 0,
+                "cursor": 0,
+            }
+        if path == "/aweme/v1/web/mix/listcollection/":
+            return {
+                "status_code": 0,
+                "mix_infos": [{"mix_id": "mix-1"}],
+                "has_more": 0,
+                "cursor": 0,
+            }
+        return {"status_code": 0, "has_more": 0, "cursor": 0}
+
+    monkeypatch.setattr(client, "_request_json", _fake_request_json)
+
+    collects_data = await client.get_user_collects("self", max_cursor=0, count=10)
+    collect_aweme_data = await client.get_collect_aweme(
+        "collect-1", max_cursor=0, count=10
+    )
+    collect_mix_data = await client.get_user_collect_mix(
+        "self", max_cursor=0, count=12
+    )
+
+    assert [path for path, _params in called_requests] == [
+        "/aweme/v1/web/collects/list/",
+        "/aweme/v1/web/collects/video/list/",
+        "/aweme/v1/web/mix/listcollection/",
+    ]
+    assert called_requests[0][1]["count"] == 10
+    assert called_requests[0][1]["version_code"] == "170400"
+    assert called_requests[1][1]["collects_id"] == "collect-1"
+    assert called_requests[1][1]["count"] == 10
+    assert called_requests[2][1]["count"] == 12
+    assert collects_data["items"] == [{"collects_id_str": "collect-1"}]
+    assert collects_data["has_more"] is True
+    assert collects_data["max_cursor"] == 9
+    assert collect_aweme_data["items"] == [{"aweme_id": "aweme-1"}]
+    assert collect_mix_data["items"] == [{"mix_id": "mix-1"}]
+
+
+@pytest.mark.asyncio
 async def test_mix_and_music_endpoints_are_normalized(monkeypatch):
     client = DouyinAPIClient({"msToken": "token-1"})
 

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1,0 +1,104 @@
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+main_module = importlib.import_module("cli.main")
+
+
+class _FakeCookieManager:
+    def get_cookies(self):
+        return {"msToken": "token-1"}
+
+
+class _FakeAPIClient:
+    def __init__(self, _cookies, proxy=None):
+        self.proxy = proxy
+        self.resolved_urls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def resolve_short_url(self, short_url: str):
+        self.resolved_urls.append(short_url)
+        return "https://www.douyin.com/video/7604129988555574538"
+
+
+class _FakeDownloader:
+    async def download(self, parsed):
+        return SimpleNamespace(total=1, success=1, failed=0, skipped=0, parsed=parsed)
+
+
+@pytest.mark.asyncio
+async def test_download_url_resolves_short_link_before_parsing(monkeypatch, tmp_path):
+    config = main_module.ConfigLoader()
+    config.update(path=str(tmp_path))
+
+    parsed_inputs = []
+
+    def _fake_parse(url: str):
+        parsed_inputs.append(url)
+        return {"type": "video", "aweme_id": "7604129988555574538"}
+
+    fake_downloader = _FakeDownloader()
+
+    monkeypatch.setattr(main_module, "DouyinAPIClient", _FakeAPIClient)
+    monkeypatch.setattr(main_module.URLParser, "parse", _fake_parse)
+    monkeypatch.setattr(
+        main_module.DownloaderFactory,
+        "create",
+        lambda *_args, **_kwargs: fake_downloader,
+    )
+
+    result = await main_module.download_url(
+        "https://v.douyin.com/short-link/",
+        config,
+        _FakeCookieManager(),
+        database=None,
+        progress_reporter=None,
+    )
+
+    assert result is not None
+    assert result.success == 1
+    assert parsed_inputs == ["https://www.douyin.com/video/7604129988555574538"]
+
+
+@pytest.mark.asyncio
+async def test_download_url_passes_proxy_to_api_client(monkeypatch, tmp_path):
+    config = main_module.ConfigLoader()
+    config.update(path=str(tmp_path), proxy="http://127.0.0.1:8899")
+
+    captured = {}
+
+    class _ProxyAPIClient(_FakeAPIClient):
+        def __init__(self, cookies, proxy=None):
+            captured["cookies"] = cookies
+            captured["proxy"] = proxy
+            super().__init__(cookies, proxy=proxy)
+
+    monkeypatch.setattr(main_module, "DouyinAPIClient", _ProxyAPIClient)
+    monkeypatch.setattr(
+        main_module.URLParser,
+        "parse",
+        lambda _url: {"type": "video", "aweme_id": "7604129988555574538"},
+    )
+    monkeypatch.setattr(
+        main_module.DownloaderFactory,
+        "create",
+        lambda *_args, **_kwargs: _FakeDownloader(),
+    )
+
+    result = await main_module.download_url(
+        "https://www.douyin.com/video/7604129988555574538",
+        config,
+        _FakeCookieManager(),
+        database=None,
+        progress_reporter=None,
+    )
+
+    assert result is not None
+    assert result.success == 1
+    assert captured["proxy"] == "http://127.0.0.1:8899"

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -96,6 +96,24 @@ progress:
     assert progress.get("quiet_logs") is False
 
 
+def test_config_loader_supports_proxy_from_env(tmp_path, monkeypatch):
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(
+        """
+link:
+  - https://www.douyin.com/video/1
+path: ./Downloaded/
+proxy: http://127.0.0.1:7890
+"""
+    )
+
+    monkeypatch.setenv("DOUYIN_PROXY", "http://127.0.0.1:8899")
+
+    loader = ConfigLoader(str(config_file))
+
+    assert loader.get("proxy") == "http://127.0.0.1:8899"
+
+
 def test_nested_defaults_do_not_leak_between_loader_instances(tmp_path):
     config_file = tmp_path / "config.yml"
     config_file.write_text(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,4 +1,5 @@
 import json
+import asyncio
 
 import pytest
 
@@ -82,5 +83,37 @@ async def test_database_transcript_job_upsert(tmp_path):
     row = await database.get_transcript_job("123")
     assert row["status"] == "success"
     assert row["skip_reason"] is None
+
+    await database.close()
+
+
+@pytest.mark.asyncio
+async def test_database_get_conn_reuses_single_connection_under_concurrency(
+    tmp_path, monkeypatch
+):
+    import storage.database as database_module
+
+    connect_calls = []
+
+    class _FakeConn:
+        def __init__(self, db_path: str):
+            self.db_path = db_path
+            self.closed = False
+
+        async def close(self):
+            self.closed = True
+
+    async def _fake_connect(db_path: str):
+        connect_calls.append(db_path)
+        await asyncio.sleep(0)
+        return _FakeConn(db_path)
+
+    monkeypatch.setattr(database_module.aiosqlite, "connect", _fake_connect)
+
+    database = Database(str(tmp_path / "test.db"))
+    conn_a, conn_b = await asyncio.gather(database._get_conn(), database._get_conn())
+
+    assert conn_a is conn_b
+    assert connect_calls == [str(tmp_path / "test.db")]
 
     await database.close()

--- a/tests/test_music_downloader.py
+++ b/tests/test_music_downloader.py
@@ -97,3 +97,70 @@ async def test_music_downloader_uses_extension_from_music_url(tmp_path, monkeypa
 
     assert result.success == 1
     assert any(path.suffix == ".m4a" for path in saved_paths)
+
+
+@pytest.mark.asyncio
+async def test_music_downloader_falls_back_to_first_aweme_when_direct_audio_missing(
+    tmp_path, monkeypatch
+):
+    class _FallbackAPIClient(_FakeAPIClient):
+        async def get_music_detail(self, _music_id: str):
+            return {
+                "title": "fallback-music",
+                "author_name": "fallback-author",
+            }
+
+        async def get_music_aweme(self, _music_id: str, cursor: int = 0, count: int = 1):
+            assert cursor == 0
+            assert count == 1
+            return {
+                "items": [
+                    {
+                        "aweme_id": "fallback-aweme-1",
+                        "author": {"nickname": "fallback-author"},
+                        "video": {
+                            "play_addr": {"url_list": ["https://example.com/video.mp4"]}
+                        },
+                    }
+                ]
+            }
+
+    config = ConfigLoader()
+    config.update(path=str(tmp_path), cover=False, json=False)
+    file_manager = FileManager(str(tmp_path))
+    downloader = MusicDownloader(
+        config=config,
+        api_client=_FallbackAPIClient(),
+        file_manager=file_manager,
+        cookie_manager=CookieManager(str(tmp_path / ".cookies.json")),
+        database=None,
+        rate_limiter=RateLimiter(max_per_second=10),
+        retry_handler=RetryHandler(max_retries=1),
+        queue_manager=QueueManager(max_workers=1),
+    )
+
+    downloaded_awemes = []
+
+    async def _fake_should_download(self, _aweme_id: str):
+        return True
+
+    async def _fake_download_aweme_assets(self, aweme_data, author_name, mode=None):
+        downloaded_awemes.append((aweme_data["aweme_id"], author_name, mode))
+        return True
+
+    monkeypatch.setattr(
+        downloader,
+        "_should_download",
+        _fake_should_download.__get__(downloader, MusicDownloader),
+    )
+    monkeypatch.setattr(
+        downloader,
+        "_download_aweme_assets",
+        _fake_download_aweme_assets.__get__(downloader, MusicDownloader),
+    )
+
+    result = await downloader.download({"music_id": "7600224486650122001"})
+
+    assert result.total == 1
+    assert result.success == 1
+    assert downloaded_awemes == [("fallback-aweme-1", "fallback-author", "music")]

--- a/tests/test_url_parser.py
+++ b/tests/test_url_parser.py
@@ -20,6 +20,16 @@ def test_parse_gallery_url_sets_aweme_id():
     assert parsed['note_id'] == '7320876060210373923'
 
 
+def test_parse_gallery_path_url_sets_aweme_id():
+    url = "https://www.douyin.com/gallery/7320876060210373923"
+    parsed = URLParser.parse(url)
+
+    assert parsed is not None
+    assert parsed["type"] == "gallery"
+    assert parsed["aweme_id"] == "7320876060210373923"
+    assert parsed["note_id"] == "7320876060210373923"
+
+
 def test_parse_collection_url_sets_mix_id():
     url = "https://www.douyin.com/collection/7320876060210373923"
     parsed = URLParser.parse(url)

--- a/tests/test_user_downloader_modes.py
+++ b/tests/test_user_downloader_modes.py
@@ -34,7 +34,13 @@ class _NoopRateLimiter:
 
 
 class _FakeAPIClient:
+    def __init__(self):
+        self.user_info_calls = []
+        self.collect_calls = 0
+        self.collect_mix_calls = 0
+
     async def get_user_info(self, _sec_uid: str):
+        self.user_info_calls.append(_sec_uid)
         return {"uid": "uid-1", "nickname": "tester", "aweme_count": 99}
 
     async def get_user_post(self, _sec_uid: str, max_cursor: int = 0, count: int = 20):
@@ -68,6 +74,28 @@ class _FakeAPIClient:
     async def get_user_music(self, _sec_uid: str, max_cursor: int = 0, count: int = 20):
         return {
             "items": [_make_aweme("555")],
+            "has_more": False,
+            "max_cursor": 0,
+            "status_code": 0,
+        }
+
+    async def get_user_collects(
+        self, _sec_uid: str, max_cursor: int = 0, count: int = 20
+    ):
+        self.collect_calls += 1
+        return {
+            "items": [{"collects_id_str": "collect-1", "collects_name": "默认收藏夹"}],
+            "has_more": False,
+            "max_cursor": 0,
+            "status_code": 0,
+        }
+
+    async def get_collect_aweme(
+        self, collects_id: str, max_cursor: int = 0, count: int = 20
+    ):
+        assert collects_id == "collect-1"
+        return {
+            "items": [_make_aweme("666")],
             "has_more": False,
             "max_cursor": 0,
             "status_code": 0,
@@ -136,3 +164,64 @@ def test_user_downloader_supports_mix_and_music_modes(tmp_path, monkeypatch):
 
     assert result.total == 2
     assert result.success == 2
+
+
+def test_user_downloader_supports_self_collect_mode(tmp_path, monkeypatch):
+    downloader = _build_downloader(tmp_path, mode=["collect"])
+
+    async def _always_true(*_args, **_kwargs):
+        return True
+
+    async def _download_ok(*_args, **_kwargs):
+        return True
+
+    monkeypatch.setattr(downloader, "_should_download", _always_true)
+    monkeypatch.setattr(downloader, "_download_aweme_assets", _download_ok)
+
+    result = asyncio.run(downloader.download({"sec_uid": "self"}))
+
+    assert result.total == 1
+    assert result.success == 1
+    assert downloader.api_client.user_info_calls == []
+
+
+def test_user_downloader_rejects_non_self_collect_mode(tmp_path, monkeypatch):
+    downloader = _build_downloader(tmp_path, mode=["collect"])
+
+    async def _always_true(*_args, **_kwargs):
+        return True
+
+    async def _download_ok(*_args, **_kwargs):
+        return True
+
+    monkeypatch.setattr(downloader, "_should_download", _always_true)
+    monkeypatch.setattr(downloader, "_download_aweme_assets", _download_ok)
+
+    result = asyncio.run(downloader.download({"sec_uid": "sec_uid_x"}))
+
+    assert result.total == 0
+    assert result.success == 0
+    assert downloader.api_client.user_info_calls == []
+    assert downloader.api_client.collect_calls == 0
+
+
+def test_user_downloader_rejects_mixed_self_collect_and_regular_modes(
+    tmp_path, monkeypatch
+):
+    downloader = _build_downloader(tmp_path, mode=["collect", "post"])
+
+    async def _always_true(*_args, **_kwargs):
+        return True
+
+    async def _download_ok(*_args, **_kwargs):
+        return True
+
+    monkeypatch.setattr(downloader, "_should_download", _always_true)
+    monkeypatch.setattr(downloader, "_download_aweme_assets", _download_ok)
+
+    result = asyncio.run(downloader.download({"sec_uid": "self"}))
+
+    assert result.total == 0
+    assert result.success == 0
+    assert downloader.api_client.user_info_calls == []
+    assert downloader.api_client.collect_calls == 0

--- a/tests/test_user_mode_registry.py
+++ b/tests/test_user_mode_registry.py
@@ -1,5 +1,7 @@
 from core.user_mode_registry import UserModeRegistry
 from core.user_modes.like_strategy import LikeUserModeStrategy
+from core.user_modes.collect_strategy import CollectUserModeStrategy
+from core.user_modes.collect_mix_strategy import CollectMixUserModeStrategy
 from core.user_modes.mix_strategy import MixUserModeStrategy
 from core.user_modes.music_strategy import MusicUserModeStrategy
 from core.user_modes.post_strategy import PostUserModeStrategy
@@ -12,4 +14,6 @@ def test_user_mode_registry_contains_default_modes():
     assert registry.get("like") is LikeUserModeStrategy
     assert registry.get("mix") is MixUserModeStrategy
     assert registry.get("music") is MusicUserModeStrategy
+    assert registry.get("collect") is CollectUserModeStrategy
+    assert registry.get("collectmix") is CollectMixUserModeStrategy
     assert registry.get("unknown") is None

--- a/tests/test_user_mode_strategies.py
+++ b/tests/test_user_mode_strategies.py
@@ -429,6 +429,49 @@ def test_collect_mix_strategy_expands_collected_mix_items():
     assert [item["aweme_id"] for item in items] == ["mix-aweme-1", "mix-aweme-2"]
 
 
+def test_collect_mix_strategy_keeps_direct_aweme_items_and_expands_remaining_metadata():
+    class _API:
+        async def get_user_collect_mix(self, _sec_uid, max_cursor=0, count=20):
+            return {
+                "items": [
+                    {"aweme_id": "mix-preview-1"},
+                    {"mix_info": {"mix_id": "mix-1"}},
+                ],
+                "has_more": False,
+                "max_cursor": 0,
+            }
+
+        async def get_mix_aweme(self, mix_id, cursor=0, count=20):
+            assert mix_id == "mix-1"
+            return {
+                "items": [{"aweme_id": "mix-aweme-1"}],
+                "has_more": False,
+                "max_cursor": 0,
+            }
+
+    class _Downloader:
+        def __init__(self):
+            self.api_client = _API()
+            self.rate_limiter = _NoopRateLimiter()
+            self.database = None
+            self.config = type(
+                "Cfg",
+                (),
+                {
+                    "get": lambda _self, key, default=None: {
+                        "number": {"collectmix": 0},
+                        "increase": {"collectmix": False},
+                    }.get(key, default)
+                },
+            )()
+            self._filter_by_time = lambda items: items
+            self._limit_count = lambda items, _mode: items
+
+    strategy = CollectMixUserModeStrategy(_Downloader())
+    items = asyncio.run(strategy.collect_items("self", {"uid": "self"}))
+    assert [item["aweme_id"] for item in items] == ["mix-preview-1", "mix-aweme-1"]
+
+
 def test_collect_mix_strategy_expansion_does_not_apply_number_limit_or_increase_early():
     class _Database:
         async def get_latest_aweme_time(self, _author_id):

--- a/tests/test_user_mode_strategies.py
+++ b/tests/test_user_mode_strategies.py
@@ -1,5 +1,7 @@
 import asyncio
 
+from core.user_modes.collect_mix_strategy import CollectMixUserModeStrategy
+from core.user_modes.collect_strategy import CollectUserModeStrategy
 from core.user_modes.like_strategy import LikeUserModeStrategy
 from core.user_modes.mix_strategy import MixUserModeStrategy
 from core.user_modes.music_strategy import MusicUserModeStrategy
@@ -274,3 +276,206 @@ def test_music_strategy_expansion_does_not_apply_number_limit_early():
     strategy = MusicUserModeStrategy(_Downloader())
     items = asyncio.run(strategy.collect_items("sec_uid_x", {"uid": "uid-1"}))
     assert [item["aweme_id"] for item in items] == ["mu-1", "mu-2"]
+
+
+def test_collect_strategy_expands_collect_folders_and_deduplicates_aweme():
+    class _API:
+        async def get_user_collects(self, _sec_uid, max_cursor=0, count=20):
+            if max_cursor > 0:
+                return {"items": [], "has_more": False, "max_cursor": max_cursor}
+            return {
+                "items": [
+                    {"collects_id_str": "collect-1"},
+                    {"collects_id_str": "collect-2"},
+                ],
+                "has_more": False,
+                "max_cursor": 0,
+            }
+
+        async def get_collect_aweme(self, collects_id, max_cursor=0, count=20):
+            assert max_cursor == 0
+            if collects_id == "collect-1":
+                return {
+                    "items": [{"aweme_id": "c-1"}, {"aweme_id": "dup"}],
+                    "has_more": False,
+                    "max_cursor": 0,
+                }
+            return {
+                "items": [{"aweme_id": "dup"}, {"aweme_id": "c-2"}],
+                "has_more": False,
+                "max_cursor": 0,
+            }
+
+    class _Downloader:
+        def __init__(self):
+            self.api_client = _API()
+            self.rate_limiter = _NoopRateLimiter()
+            self.database = None
+            self.config = type(
+                "Cfg",
+                (),
+                {
+                    "get": lambda _self, key, default=None: {
+                        "number": {"collect": 0},
+                        "increase": {"collect": False},
+                    }.get(key, default)
+                },
+            )()
+            self._filter_by_time = lambda items: items
+            self._limit_count = lambda items, _mode: items
+
+    strategy = CollectUserModeStrategy(_Downloader())
+    items = asyncio.run(strategy.collect_items("self", {"uid": "self"}))
+    assert [item["aweme_id"] for item in items] == ["c-1", "dup", "c-2"]
+
+
+def test_collect_strategy_expansion_does_not_apply_number_limit_or_increase_early():
+    class _Database:
+        async def get_latest_aweme_time(self, _author_id):
+            return 1700000000
+
+    class _API:
+        async def get_user_collects(self, _sec_uid, max_cursor=0, count=20):
+            return {
+                "items": [
+                    {"collects_id_str": "collect-1"},
+                    {"collects_id_str": "collect-2"},
+                ],
+                "has_more": False,
+                "max_cursor": 0,
+            }
+
+        async def get_collect_aweme(self, collects_id, max_cursor=0, count=20):
+            if collects_id == "collect-1":
+                return {
+                    "items": [{"aweme_id": "c-1", "create_time": 1700000001}],
+                    "has_more": False,
+                    "max_cursor": 0,
+                }
+            return {
+                "items": [{"aweme_id": "c-2", "create_time": 1700000002}],
+                "has_more": False,
+                "max_cursor": 0,
+            }
+
+    class _Downloader:
+        def __init__(self):
+            self.api_client = _API()
+            self.rate_limiter = _NoopRateLimiter()
+            self.database = _Database()
+            self.config = type(
+                "Cfg",
+                (),
+                {
+                    "get": lambda _self, key, default=None: {
+                        "number": {"collect": 1},
+                        "increase": {"collect": True},
+                    }.get(key, default)
+                },
+            )()
+            self._filter_by_time = lambda items: items
+            self._limit_count = lambda items, _mode: items
+
+    strategy = CollectUserModeStrategy(_Downloader())
+    items = asyncio.run(strategy.collect_items("self", {"uid": "self"}))
+    assert [item["aweme_id"] for item in items] == ["c-1", "c-2"]
+
+
+def test_collect_mix_strategy_expands_collected_mix_items():
+    class _API:
+        async def get_user_collect_mix(self, _sec_uid, max_cursor=0, count=20):
+            return {
+                "items": [
+                    {"mix_info": {"mix_id": "mix-1"}},
+                    {"mix_id": "mix-2"},
+                ],
+                "has_more": False,
+                "max_cursor": 0,
+            }
+
+        async def get_mix_aweme(self, mix_id, cursor=0, count=20):
+            if mix_id == "mix-1":
+                return {
+                    "items": [{"aweme_id": "mix-aweme-1"}],
+                    "has_more": False,
+                    "max_cursor": 0,
+                }
+            return {
+                "items": [{"aweme_id": "mix-aweme-2"}],
+                "has_more": False,
+                "max_cursor": 0,
+            }
+
+    class _Downloader:
+        def __init__(self):
+            self.api_client = _API()
+            self.rate_limiter = _NoopRateLimiter()
+            self.database = None
+            self.config = type(
+                "Cfg",
+                (),
+                {
+                    "get": lambda _self, key, default=None: {
+                        "number": {"collectmix": 0},
+                        "increase": {"collectmix": False},
+                    }.get(key, default)
+                },
+            )()
+            self._filter_by_time = lambda items: items
+            self._limit_count = lambda items, _mode: items
+
+    strategy = CollectMixUserModeStrategy(_Downloader())
+    items = asyncio.run(strategy.collect_items("self", {"uid": "self"}))
+    assert [item["aweme_id"] for item in items] == ["mix-aweme-1", "mix-aweme-2"]
+
+
+def test_collect_mix_strategy_expansion_does_not_apply_number_limit_or_increase_early():
+    class _Database:
+        async def get_latest_aweme_time(self, _author_id):
+            return 1700000000
+
+    class _API:
+        async def get_user_collect_mix(self, _sec_uid, max_cursor=0, count=20):
+            return {
+                "items": [
+                    {"mix_info": {"mix_id": "mix-1"}},
+                    {"mix_info": {"mix_id": "mix-2"}},
+                ],
+                "has_more": False,
+                "max_cursor": 0,
+            }
+
+        async def get_mix_aweme(self, mix_id, cursor=0, count=20):
+            if mix_id == "mix-1":
+                return {
+                    "items": [{"aweme_id": "mix-aweme-1", "create_time": 1700000001}],
+                    "has_more": False,
+                    "max_cursor": 0,
+                }
+            return {
+                "items": [{"aweme_id": "mix-aweme-2", "create_time": 1700000002}],
+                "has_more": False,
+                "max_cursor": 0,
+            }
+
+    class _Downloader:
+        def __init__(self):
+            self.api_client = _API()
+            self.rate_limiter = _NoopRateLimiter()
+            self.database = _Database()
+            self.config = type(
+                "Cfg",
+                (),
+                {
+                    "get": lambda _self, key, default=None: {
+                        "number": {"collectmix": 1},
+                        "increase": {"collectmix": True},
+                    }.get(key, default)
+                },
+            )()
+            self._filter_by_time = lambda items: items
+            self._limit_count = lambda items, _mode: items
+
+    strategy = CollectMixUserModeStrategy(_Downloader())
+    items = asyncio.run(strategy.collect_items("self", {"uid": "self"}))
+    assert [item["aweme_id"] for item in items] == ["mix-aweme-1", "mix-aweme-2"]

--- a/tests/test_video_downloader.py
+++ b/tests/test_video_downloader.py
@@ -258,6 +258,63 @@ async def test_download_aweme_assets_keeps_success_when_transcript_skipped(
 
 
 @pytest.mark.asyncio
+async def test_download_aweme_assets_video_writes_cover_avatar_and_json(
+    tmp_path, monkeypatch
+):
+    downloader, api_client = _build_downloader(tmp_path)
+    downloader.config.update(
+        music=False,
+        cover=True,
+        avatar=True,
+        json=True,
+        folderstyle=True,
+        transcript={"enabled": False},
+    )
+
+    async def _fake_get_session():
+        return object()
+
+    monkeypatch.setattr(api_client, "get_session", _fake_get_session)
+
+    saved_paths = []
+
+    async def _fake_download_with_retry(self, _url, save_path, _session, **_kwargs):
+        saved_paths.append(save_path)
+        return True
+
+    downloader._download_with_retry = _fake_download_with_retry.__get__(
+        downloader, VideoDownloader
+    )
+
+    aweme_data = {
+        "aweme_id": "7600224486650121527",
+        "desc": "附加资源",
+        "create_time": 1707303025,
+        "author": {
+            "nickname": "测试作者",
+            "avatar_larger": {"url_list": ["https://example.com/avatar.jpg"]},
+        },
+        "video": {
+            "play_addr": {"url_list": ["https://example.com/video.mp4"]},
+            "cover": {"url_list": ["https://example.com/cover.jpg"]},
+        },
+    }
+
+    success = await downloader._download_aweme_assets(
+        aweme_data, author_name="测试作者", mode="post"
+    )
+
+    assert success is True
+    assert any(path.name.endswith(".mp4") for path in saved_paths)
+    assert any(path.name.endswith("_cover.jpg") for path in saved_paths)
+    assert any(path.name.endswith("_avatar.jpg") for path in saved_paths)
+    metadata_files = list(tmp_path.rglob("*_data.json"))
+    assert len(metadata_files) == 1
+
+    await api_client.close()
+
+
+@pytest.mark.asyncio
 async def test_download_aweme_assets_gallery_downloads_live_photo_videos(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- add `collect` and `collectmix` modes for logged-in favorites flows, plus self-only scope validation and strategy-based paging expansion
- harden downloader behavior with `/gallery/{id}` parsing, proxy propagation, SQLite init locking, and config/documentation cleanup
- expand regression coverage across CLI, URL parsing, API/config/database behavior, and user-mode edge cases

## Test Plan
- [x] `python3 -m pytest -q`
- [x] `pytest -q`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `collect` and `collectmix` download modes for the logged-in user's Douyin favorites, hardens several existing subsystems (proxy propagation end-to-end, SQLite init locking, `/gallery/{id}` URL parsing), and adds broad regression coverage across 8 new/extended test files.

**Key changes:**
- Two new strategy classes (`CollectUserModeStrategy`, `CollectMixUserModeStrategy`) implement two-level pagination for favorited items and mixes, with deduplication and cursor-stuck safeguards
- `_validate_mode_scope` in `UserDownloader` enforces that `collect`/`collectmix` can only be used with `/user/self` URLs and cannot be mixed with regular modes
- Proxy is now consistently threaded through `DouyinAPIClient` → `_request_json` → `FileManager.download_file`
- Critical bug fix: `Database._get_conn` was creating a new `asyncio.Lock()` on every call (effectively no locking); it now uses a persistent `_conn_lock` instance attribute
- `URLParser` extended to match `/gallery/{id}` in addition to `/note/{id}` for image-note URLs
- `_collect_paged_entries` added to `BaseUserModeStrategy` as a reusable metadata pager that intentionally skips per-page number/increase filters (those are applied after full expansion)

**Issues found:**
- In `CollectMixUserModeStrategy.collect_items`, the fast-path return triggers if *any* item in the mix list carries an `aweme_id`, which would silently drop the remaining mix-metadata items that require expansion via `get_mix_aweme`
- `_build_collect_page_params` in `api_client.py` redundantly re-sets `version_code` and `version_name` that are already present in `_default_query()`
- `Database.initialize()` still lacks the double-checked lock protection that was correctly applied to `_get_conn`, leaving a minor TOCTOU window under concurrent callers

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor review items; the one functional logic issue in `CollectMixUserModeStrategy` is unlikely to be triggered by the current API but could silently drop data if the API response format changes.
- The core bug fixes (SQLite lock, proxy propagation) are correct and well-tested. The new collect strategies are solid with good pagination safety guards. The one logic concern in `collect_mix_strategy.py` (partial aweme match causing early return) is unlikely to surface given the current API contract, but represents a latent data-loss risk. The redundant version params and the unlocked `initialize()` are minor style/robustness issues. Test coverage is comprehensive and the approach is architecturally consistent with existing strategies.
- Pay close attention to `core/user_modes/collect_mix_strategy.py` (partial-match early return) and `storage/database.py` (`initialize()` still unprotected by lock).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| core/user_modes/collect_strategy.py | New strategy for downloading favorited items; implements two-level pagination (folder list → per-folder aweme list) with deduplication via `seen_aweme` set and cursor-stuck safeguard. |
| core/user_modes/collect_mix_strategy.py | New strategy for downloaded collected mixes; contains a logic issue where the fast-path aweme return triggers if any item has `aweme_id`, silently dropping remaining mix-metadata items that require expansion. |
| storage/database.py | Fixes a critical bug where `_get_conn` created a new `asyncio.Lock()` on each call (making the lock useless); now stores `_conn_lock` as an instance attribute. The `initialize()` method still lacks equivalent lock protection. |
| core/api_client.py | Adds proxy support via constructor parameter; propagates `proxy` to `_request_json` and `resolve_short_url` calls. Adds three new collect-related API methods. `_build_collect_page_params` redundantly re-declares defaults already present in `_default_query`. |
| core/user_modes/base_strategy.py | Adds shared `_collect_paged_entries` helper that paginates metadata (folders/mixes) without applying number/increase filters, correctly separating the two paging concerns. |
| core/user_downloader.py | Adds `_validate_mode_scope` to reject `collect`/`collectmix` for non-self UIDs or when mixed with regular modes, and `_resolve_user_info` to skip the API call for self-collect flows returning a synthetic user dict. |
| storage/file_manager.py | Adds optional `proxy` parameter to `download_file`; correctly normalises empty string to `None` before passing to aiohttp. |
| tests/test_user_mode_strategies.py | Adds comprehensive tests for collect and collectmix strategies, including deduplication, cursor-stuck guard, and verifying that number/increase limits are not applied within the expansion phase. |
| tests/test_database.py | Adds concurrent `_get_conn` test confirming the lock fix: two concurrent callers receive the same connection object and only one `aiosqlite.connect` call is made. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[UserDownloader.download] --> B{_validate_mode_scope}
    B -- collect/collectmix + non-self UID --> C[Return empty result]
    B -- collect/collectmix + regular modes --> C
    B -- valid --> D{_resolve_user_info}
    D -- sec_uid == self & collect modes --> E[Return synthetic user dict]
    D -- regular UID --> F[api_client.get_user_info]
    E --> G[UserModeRegistry.get strategy]
    F --> G
    G --> H{Mode?}
    H -- collect --> I[CollectUserModeStrategy.collect_items]
    H -- collectmix --> J[CollectMixUserModeStrategy.collect_items]
    H -- post/like/mix/music --> K[Existing strategies]

    I --> I1[_collect_paged_entries: fetch folder list]
    I1 --> I2[For each folder: paginate get_collect_aweme]
    I2 --> I3[Deduplicate via seen_aweme set]
    I3 --> I4[Return flat aweme list]

    J --> J1[_collect_paged_entries: fetch mix list]
    J1 --> J2{Any item has aweme_id?}
    J2 -- yes --> J3[Return aweme_items early ⚠️ may drop remaining]
    J2 -- no --> J4[_normalize_mix_item for each]
    J4 --> J5[_expand_metadata_items via get_mix_aweme]
    J5 --> J6[Return flat aweme list]

    I4 --> L[BaseUserModeStrategy.apply_filters]
    J3 --> L
    J6 --> L
    K --> L
    L --> M[_filter_by_time]
    M --> N[_limit_count]
    N --> O[_download_mode_items]
    O --> P[FileManager.download_file proxy=api_client.proxy]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `core/api_client.py`, line 445-457 ([link](https://github.com/jiji262/douyin-downloader/blob/e2bede204f19ff76fa0a271cfd9213a7752a3019/core/api_client.py#L445-L457)) 

   **`_build_collect_page_params` redundantly re-sets defaults already present in `_default_query`**

   `_default_query()` already includes `"version_code": "170400"` and `"version_name": "17.4.0"` (lines 134–135). The explicit `.update()` call here repeats the same values and will be silently ignored unless those defaults ever change — at which point the override here would become a hidden discrepancy.

   If the intent is to pin these to a specific version regardless of what `_default_query` produces in the future, add a comment. Otherwise, the redundant keys can be removed:

   ```python
   async def _build_collect_page_params(
       self, max_cursor: int, count: int
   ) -> Dict[str, Any]:
       params = await self._default_query()
       params.update(
           {
               "cursor": max_cursor,
               "count": count,
           }
       )
       return params
   ```


2. `storage/database.py`, line 21-23 ([link](https://github.com/jiji262/douyin-downloader/blob/e2bede204f19ff76fa0a271cfd9213a7752a3019/storage/database.py#L21-L23)) 

   **`initialize()` not protected by the new `_conn_lock`**

   The PR correctly fixes `_get_conn` to use a persistent `_conn_lock` instead of a freshly-created `asyncio.Lock()` on every call. However, `initialize()` still has the same TOCTOU pattern: two concurrent callers both see `_initialized = False`, both proceed past the guard, and both execute the `CREATE TABLE` / `CREATE INDEX` DDL statements before either sets `self._initialized = True`.

   Because all statements are idempotent (`IF NOT EXISTS`) and aiosqlite serialises writes, this doesn't produce data corruption today. But the schema setup runs twice (or more), wasting round-trips and creating unnecessary log noise. Consider extending the lock pattern:

   ```python
   async def initialize(self):
       if self._initialized:
           return
       async with self._conn_lock:
           if self._initialized:
               return
           # ... DDL statements ...
           self._initialized = True
   ```

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: e2bede2</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->