### PR TITLE
fix: tighten note cookie auto handling

### DIFF
--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -226,11 +226,13 @@ class ConfigLoader:
         if not path.exists():
             return {}
         try:
-            raw_data = json.loads(path.read_text(encoding="utf-8")) or {}
+            raw_data = json.loads(path.read_text(encoding="utf-8"))
         except Exception as exc:
             logger.warning("Failed to load auto cookie file %s: %s", path, exc)
             return {}
 
+        if raw_data is None:
+            return {}
         if not isinstance(raw_data, dict):
             logger.warning("Auto cookie file %s is not a JSON object", path)
             return {}

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -1,3 +1,4 @@
+import json
 import os
 import logging
 from copy import deepcopy
@@ -164,15 +165,76 @@ class ConfigLoader:
         cookies_config = self.config.get("cookies") or self.config.get("cookie")
 
         if isinstance(cookies_config, str):
-            if cookies_config == "auto":
-                return {}
+            if cookies_config.strip().lower() == "auto":
+                return self._load_auto_cookies()
             return self._parse_cookie_string(cookies_config)
         elif isinstance(cookies_config, dict):
             return sanitize_cookies(cookies_config)
+        if self._auto_cookie_enabled():
+            return self._load_auto_cookies()
         return {}
 
     def _parse_cookie_string(self, cookie_str: str) -> Dict[str, str]:
         return sanitize_cookies(parse_cookie_header(cookie_str))
+
+    def _auto_cookie_enabled(self) -> bool:
+        raw_value = self.config.get("auto_cookie")
+        if isinstance(raw_value, str):
+            return raw_value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(raw_value)
+
+    def _load_auto_cookies(self) -> Dict[str, str]:
+        for path in self._candidate_auto_cookie_paths():
+            cookies = self._load_cookie_file(path)
+            if cookies:
+                logger.info("Loaded auto cookies from %s", path)
+                return cookies
+        return {}
+
+    def _candidate_auto_cookie_paths(self) -> List[Path]:
+        config_dir = (
+            Path(self.config_path).resolve().parent
+            if self.config_path
+            else Path.cwd().resolve()
+        )
+        search_roots = [
+            config_dir,
+            config_dir.parent,
+            Path.cwd().resolve(),
+        ]
+        candidates: List[Path] = []
+        for root in search_roots:
+            candidates.extend(
+                [
+                    root / "config" / "cookies.json",
+                    root / ".cookies.json",
+                ]
+            )
+
+        unique: List[Path] = []
+        seen: set[str] = set()
+        for candidate in candidates:
+            resolved = str(candidate.resolve())
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            unique.append(candidate)
+        return unique
+
+    @staticmethod
+    def _load_cookie_file(path: Path) -> Dict[str, str]:
+        if not path.exists():
+            return {}
+        try:
+            raw_data = json.loads(path.read_text(encoding="utf-8")) or {}
+        except Exception as exc:
+            logger.warning("Failed to load auto cookie file %s: %s", path, exc)
+            return {}
+
+        if not isinstance(raw_data, dict):
+            logger.warning("Auto cookie file %s is not a JSON object", path)
+            return {}
+        return sanitize_cookies(raw_data)
 
     def get_links(self) -> List[str]:
         links = self.config.get("link", [])

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -60,6 +60,68 @@ cookies:
     assert cookies["msToken"] == "token"
 
 
+def test_config_loader_reads_auto_cookies_from_default_file(tmp_path):
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(
+        """
+link:
+  - https://www.douyin.com/note/1
+path: ./Downloaded/
+cookies: auto
+"""
+    )
+    cookie_dir = tmp_path / "config"
+    cookie_dir.mkdir()
+    (cookie_dir / "cookies.json").write_text(
+        """
+{
+  "ttwid": "auto-ttwid",
+  "msToken": "auto-ms-token",
+  "_waftokenid": "auto-waf-token"
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    loader = ConfigLoader(str(config_file))
+    cookies = loader.get_cookies()
+
+    assert cookies["ttwid"] == "auto-ttwid"
+    assert cookies["msToken"] == "auto-ms-token"
+    assert cookies["_waftokenid"] == "auto-waf-token"
+
+
+def test_config_loader_reads_auto_cookies_for_nested_config_path(tmp_path, monkeypatch):
+    workspace = tmp_path
+    config_dir = workspace / "config"
+    config_dir.mkdir()
+    config_file = config_dir / "config.yml"
+    config_file.write_text(
+        """
+link:
+  - https://www.douyin.com/note/1
+path: ./Downloaded/
+cookies: auto
+"""
+    )
+    (workspace / "config" / "cookies.json").write_text(
+        """
+{
+  "ttwid": "nested-ttwid",
+  "msToken": "nested-ms-token"
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workspace)
+
+    loader = ConfigLoader(str(config_file))
+    cookies = loader.get_cookies()
+
+    assert cookies["ttwid"] == "nested-ttwid"
+    assert cookies["msToken"] == "nested-ms-token"
+
+
 def test_progress_quiet_logs_default_enabled(tmp_path):
     config_file = tmp_path / "config.yml"
     config_file.write_text(

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -122,6 +122,93 @@ cookies: auto
     assert cookies["msToken"] == "nested-ms-token"
 
 
+def test_config_loader_reads_auto_cookies_when_auto_cookie_enabled(
+    tmp_path, monkeypatch
+):
+    workspace = tmp_path
+    config_file = workspace / "config.yml"
+    config_file.write_text(
+        """
+link:
+  - https://www.douyin.com/note/1
+path: ./Downloaded/
+auto_cookie: true
+"""
+    )
+    cookie_dir = workspace / "config"
+    cookie_dir.mkdir()
+    (cookie_dir / "cookies.json").write_text(
+        """
+{
+  "ttwid": "auto-ttwid",
+  "msToken": "auto-ms-token"
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workspace)
+
+    loader = ConfigLoader(str(config_file))
+    cookies = loader.get_cookies()
+
+    assert cookies["ttwid"] == "auto-ttwid"
+    assert cookies["msToken"] == "auto-ms-token"
+
+
+def test_config_loader_skips_auto_cookies_when_auto_cookie_disabled(
+    tmp_path, monkeypatch
+):
+    workspace = tmp_path
+    config_file = workspace / "config.yml"
+    config_file.write_text(
+        """
+link:
+  - https://www.douyin.com/note/1
+path: ./Downloaded/
+auto_cookie: false
+"""
+    )
+    cookie_dir = workspace / "config"
+    cookie_dir.mkdir()
+    (cookie_dir / "cookies.json").write_text(
+        """
+{
+  "ttwid": "auto-ttwid",
+  "msToken": "auto-ms-token"
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workspace)
+
+    loader = ConfigLoader(str(config_file))
+
+    assert loader.get_cookies() == {}
+
+
+def test_config_loader_warns_for_non_object_auto_cookie_file(tmp_path, caplog):
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(
+        """
+link:
+  - https://www.douyin.com/note/1
+path: ./Downloaded/
+cookies: auto
+"""
+    )
+    cookie_dir = tmp_path / "config"
+    cookie_dir.mkdir()
+    (cookie_dir / "cookies.json").write_text("[]", encoding="utf-8")
+
+    loader = ConfigLoader(str(config_file))
+    cookies = loader.get_cookies()
+
+    assert cookies == {}
+    assert any(
+        "is not a JSON object" in record.message for record in caplog.records
+    )
+
+
 def test_progress_quiet_logs_default_enabled(tmp_path):
     config_file = tmp_path / "config.yml"
     config_file.write_text(

--- a/tests/test_cookie_fetcher.py
+++ b/tests/test_cookie_fetcher.py
@@ -4,6 +4,7 @@ import time
 import pytest
 from tools.cookie_fetcher import (
     extract_ms_token_from_text,
+    filter_cookies,
     goto_with_fallback,
     try_extract_ms_token,
     wait_for_login_confirmation,
@@ -146,3 +147,23 @@ def test_extract_ms_token_from_text_supports_json_and_query_formats():
         == "query-token"
     )
     assert extract_ms_token_from_text('{"msToken":"json-token","x":1}') == "json-token"
+
+
+def test_filter_cookies_keeps_waf_and_fingerprint_keys_but_drops_unrelated_keys():
+    cookies = filter_cookies(
+        {
+            "ttwid": "ttwid-token",
+            "msToken": "ms-token",
+            "_waftokenid": "waf-token",
+            "s_v_web_id": "verify-id",
+            "__ac_signature": "ac-signature",
+            "random_cookie": "should-be-filtered",
+        }
+    )
+
+    assert cookies["ttwid"] == "ttwid-token"
+    assert cookies["msToken"] == "ms-token"
+    assert cookies["_waftokenid"] == "waf-token"
+    assert cookies["s_v_web_id"] == "verify-id"
+    assert cookies["__ac_signature"] == "ac-signature"
+    assert "random_cookie" not in cookies

--- a/tools/cookie_fetcher.py
+++ b/tools/cookie_fetcher.py
@@ -337,12 +337,11 @@ def filter_cookies(cookies: Dict[str, str]) -> Dict[str, str]:
     cookies = sanitize_cookies(cookies)
     picked = {}
     for key, value in cookies.items():
-        normalized = key.strip()
-        if normalized in SUGGESTED_KEYS or normalized in DEFAULT_AUXILIARY_KEYS:
-            picked[normalized] = value
+        if key in SUGGESTED_KEYS or key in DEFAULT_AUXILIARY_KEYS:
+            picked[key] = value
             continue
-        if any(normalized.startswith(prefix) for prefix in DEFAULT_AUXILIARY_PREFIXES):
-            picked[normalized] = value
+        if any(key.startswith(prefix) for prefix in DEFAULT_AUXILIARY_PREFIXES):
+            picked[key] = value
 
     if not picked:
         return cookies

--- a/tools/cookie_fetcher.py
+++ b/tools/cookie_fetcher.py
@@ -14,6 +14,22 @@ DEFAULT_URL = "https://www.douyin.com/"
 DEFAULT_OUTPUT = Path("config/cookies.json")
 REQUIRED_KEYS = {"msToken", "ttwid", "odin_tt", "passport_csrf_token"}
 SUGGESTED_KEYS = REQUIRED_KEYS | {"sid_guard", "sessionid", "sid_tt"}
+DEFAULT_AUXILIARY_KEYS = {
+    "_waftokenid",
+    "s_v_web_id",
+    "__ac_nonce",
+    "__ac_signature",
+    "UIFID",
+    "UIFID_TEMP",
+    "d_ticket",
+    "x-web-secsdk-uid",
+    "__security_server_data_status",
+}
+DEFAULT_AUXILIARY_PREFIXES = (
+    "__security_mc_",
+    "bd_ticket_guard_",
+    "_bd_ticket_crypt_",
+)
 PRIMARY_WAIT_UNTIL = "networkidle"
 FALLBACK_WAIT_UNTIL = "domcontentloaded"
 PRIMARY_TIMEOUT_MS = 300_000
@@ -319,7 +335,15 @@ def extract_ms_token_from_text(text: str) -> Optional[str]:
 
 def filter_cookies(cookies: Dict[str, str]) -> Dict[str, str]:
     cookies = sanitize_cookies(cookies)
-    picked = {k: v for k, v in cookies.items() if k in SUGGESTED_KEYS}
+    picked = {}
+    for key, value in cookies.items():
+        normalized = key.strip()
+        if normalized in SUGGESTED_KEYS or normalized in DEFAULT_AUXILIARY_KEYS:
+            picked[normalized] = value
+            continue
+        if any(normalized.startswith(prefix) for prefix in DEFAULT_AUXILIARY_PREFIXES):
+            picked[normalized] = value
+
     if not picked:
         return cookies
     return picked


### PR DESCRIPTION
## Summary
- load auto cookies from workspace defaults even when the config file lives under a nested `config/` path
- preserve the default cookie subset contract while keeping WAF and fingerprint keys needed for note downloads
- add regression coverage for auto cookie lookup and cookie filtering behavior

## Test Plan
- `PYTHONPATH=. pytest tests/test_config_loader.py tests/test_cookie_fetcher.py -q`
- `python3 -m compileall config/config_loader.py tools/cookie_fetcher.py tests/test_config_loader.py tests/test_cookie_fetcher.py`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the auto-cookie handling in `ConfigLoader` and `filter_cookies`. Previously, `cookies: auto` in a config file returned an empty dict; now it resolves a `cookies.json` file by searching the config directory, its parent, and the current working directory (deduplicated). The `filter_cookies` function is also widened to preserve WAF and browser-fingerprint cookie keys needed for note downloads, alongside the existing `SUGGESTED_KEYS`.

Key changes:
- `config/config_loader.py`: `cookies: auto` now calls `_load_auto_cookies`, which iterates through workspace-relative candidate paths; a new `auto_cookie` config key also enables this behaviour without an explicit `auto` string value
- `tools/cookie_fetcher.py`: `filter_cookies` extended with `DEFAULT_AUXILIARY_KEYS` (WAF/fingerprint tokens) and `DEFAULT_AUXILIARY_PREFIXES` (prefix-matched security cookies)
- `tests/`: Two new `ConfigLoader` regression tests cover the auto-cookie lookup for flat and nested config paths; one new `filter_cookies` test covers the widened key set

One logic concern was found in `_load_cookie_file`: the `json.loads(...) or {}` expression silently converts falsy non-dict JSON values (`null`, `false`, `0`, `[]`) to an empty dict before the `isinstance` guard runs, making the "Auto cookie file is not a JSON object" warning unreachable for those inputs. The `_auto_cookie_enabled()` fallback path introduced in `get_cookies` is also not covered by tests.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after addressing the `_load_cookie_file` logic issue; the rest of the changes are well-scoped and tested.
- The overall approach is sound and the path-search logic is well-designed with deduplication. However, the `json.loads(...) or {}` pattern in `_load_cookie_file` makes the isinstance warning unreachable for common malformed inputs (null, empty list), which could silently hide misconfigured cookie files. Additionally, the `auto_cookie` config key codepath has no test coverage. These lower the confidence slightly below a clean merge.
- `config/config_loader.py` — specifically `_load_cookie_file` (lines 225–237)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| config/config_loader.py | Adds `_load_auto_cookies`, `_candidate_auto_cookie_paths`, and `_load_cookie_file` to resolve cookie files from workspace-relative paths. Contains a logic issue in `_load_cookie_file` where `json.loads(...) or {}` silently bypasses the "not a JSON object" warning for falsy non-dict values. |
| tools/cookie_fetcher.py | Extends `filter_cookies` with `DEFAULT_AUXILIARY_KEYS` and `DEFAULT_AUXILIARY_PREFIXES` to preserve WAF/fingerprint cookies; the `normalized = key.strip()` line is redundant after `sanitize_cookies` but otherwise correct. |
| tests/test_config_loader.py | Adds two regression tests for the auto-cookie lookup — one for a config file at the workspace root and one for a nested `config/` path. The `auto_cookie` config key codepath remains untested. |
| tests/test_cookie_fetcher.py | Adds a test for the expanded `filter_cookies` function verifying WAF/fingerprint key retention and unrelated key exclusion. Coverage is sufficient for the new behaviour. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[get_cookies called] --> B{cookies_config type?}
    B -- string --> C{strip/lower == 'auto'?}
    C -- yes --> D[_load_auto_cookies]
    C -- no --> E[_parse_cookie_string]
    B -- dict --> F[sanitize_cookies]
    B -- other/None --> G{_auto_cookie_enabled?}
    G -- yes --> D
    G -- no --> H[return empty dict]

    D --> I[_candidate_auto_cookie_paths]
    I --> J["Roots: config_dir, config_dir.parent, cwd"]
    J --> K["Candidates: root/config/cookies.json, root/.cookies.json"]
    K --> L[Deduplicate by resolved path]
    L --> M{For each candidate}
    M -- path exists --> N[_load_cookie_file]
    N --> O{json.loads result}
    O -- parse error --> P[log warning, return empty]
    O -- not a dict --> Q[log warning, return empty]
    O -- valid dict --> R[sanitize_cookies, return]
    R --> S{cookies non-empty?}
    S -- yes --> T[log info, return cookies]
    S -- no --> M
    M -- exhausted --> H
```

<sub>Last reviewed commit: 56cc9e1</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->