### PR TITLE
fix: 修复视频下载失败，优先使用直接 CDN URL

### DIFF
--- a/core/downloader_base.py
+++ b/core/downloader_base.py
@@ -496,6 +496,8 @@ class BaseDownloader(ABC):
 
             fallback_candidate = (candidate, headers)
 
+        # Prefer direct CDN URLs (e.g. douyinvod.com) over the /aweme/v1/play/
+        # signed endpoint: the latter redirects to a URL that returns 403 Forbidden.
         if fallback_candidate:
             return fallback_candidate
 

--- a/core/downloader_base.py
+++ b/core/downloader_base.py
@@ -496,6 +496,9 @@ class BaseDownloader(ABC):
 
             fallback_candidate = (candidate, headers)
 
+        if fallback_candidate:
+            return fallback_candidate
+
         uri = (
             play_addr.get("uri")
             or video.get("vid")
@@ -514,9 +517,6 @@ class BaseDownloader(ABC):
                 "/aweme/v1/play/", params
             )
             return signed_url, self._download_headers(user_agent=ua)
-
-        if fallback_candidate:
-            return fallback_candidate
 
         return None
 


### PR DESCRIPTION
## 问题描述

单个视频下载时成功率为 0，所有视频均报 Failed。
根本原因：`_build_no_watermark_url` 方法在存在 `uri`
字段时，优先构造 `/aweme/v1/play/` 签名链接，但该接口重定向后返回
403 Forbidden，导致文件无法下载。而 `play_addr.url_list` 中的直接
CDN 地址（如 douyinvod.com）可以正常访问。

## 修复方案
调整 `_build_no_watermark_url` 中的优先级：优先返回直接 CDN
URL，仅在没有可用 CDN URL 时才回退到 `/aweme/v1/play/` 接口。

## 改动文件
- `core/downloader_base.py`：交换 `fallback_candidate` 与
`/aweme/v1/play/` 的返回顺序

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a video download failure bug by adjusting the URL priority order in `_build_no_watermark_url` within `core/downloader_base.py`. Previously, the method prioritized constructing a signed `/aweme/v1/play/` endpoint URL over direct CDN URLs (e.g., `douyinvod.com`) stored in `play_addr.url_list`, which resulted in 403 Forbidden errors after redirect. The fix moves the `fallback_candidate` (CDN URL) return above the `/aweme/v1/play/` signed URL construction, so direct CDN URLs are used when available.

**Key changes:**
- The `fallback_candidate` return is now checked *before* attempting to build a signed `/aweme/v1/play/` URL
- The `/aweme/v1/play/` signed URL path is now only used as a true last resort when `url_list` is empty or contains no usable URLs
- Priority order is now: `douyin.com` URLs (with optional signing) → direct CDN URLs → `/aweme/v1/play/` signed URL → `None`

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the change is minimal, well-motivated, and the new priority order is clearly superior to the broken status quo.
- The fix is a straightforward two-location reorder with no new logic introduced. The `fallback_candidate` return is moved above the `/aweme/v1/play/` path, which is described as consistently returning 403. The only minor caveat is that the `/aweme/v1/play/` endpoint is now effectively unreachable whenever any non-`douyin.com` URL exists in `url_list`, but since that endpoint returns 403 anyway, this is the correct behavior. A small inline comment documenting why CDN URLs are preferred over the signed API endpoint would improve long-term maintainability.
- No files require special attention — the single changed file has a low-risk, isolated code reorder.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/downloader_base.py | Priority order in `_build_no_watermark_url` swapped so direct CDN URLs are returned before falling back to the `/aweme/v1/play/` signed endpoint, fixing 403 errors on video downloads. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[_build_no_watermark_url called] --> B[Get url_list from play_addr]
    B --> C{url_list has entries?}
    C -- No --> G
    C -- Yes --> D[Iterate url_candidates sorted by watermark=0 first]
    D --> E{URL from douyin.com?}
    E -- Yes, no X-Bogus --> F1[Sign URL via api_client.sign_url]
    F1 --> RET1[Return signed douyin.com URL ✅]
    E -- Yes, has X-Bogus --> RET2[Return candidate as-is ✅]
    E -- No --> F2[Set as fallback_candidate CDN URL]
    F2 --> D
    D -- Loop done --> G{fallback_candidate set?}
    G -- Yes --> RET3["Return CDN URL e.g. douyinvod.com ✅ (MOVED UP by fix)"]
    G -- No --> H{uri or vid available?}
    H -- Yes --> I["Build signed /aweme/v1/play/ URL (was 403 before fix)"]
    I --> RET4[Return /aweme/v1/play/ signed URL ⚠️]
    H -- No --> RET5[Return None ❌]
```

<sub>Last reviewed commit: 099aae5</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->