### PR TITLE
fix: improve note/gallery download robustness

### DIFF
--- a/core/downloader_base.py
+++ b/core/downloader_base.py
@@ -565,11 +565,27 @@ class BaseDownloader(ABC):
             )
             if image_url:
                 image_urls.append(image_url)
+        gallery_items = self._iter_gallery_items(aweme_data)
+        for item in gallery_items:
+            if not isinstance(item, dict):
+                continue
+            # 优先拿可下载/原图字段，避免 preview/display 图链签名失效后整组图文失败。
+            # 同时兼容旧格式 download_url_list（直接 list）和新格式 download_url（dict with url_list）。
+            image_url = self._pick_first_media_url(
+                item.get("download_url"),
+                item.get("download_addr"),
+                item.get("download_url_list"),
+                item,
+                item.get("display_image"),
+                item.get("owner_watermark_image"),
+            )
+            if image_url:
+                image_urls.append(image_url)
         if not image_urls:
             logger.warning(
                 "No image URLs extracted for aweme %s; gallery items count=%d",
                 aweme_data.get("aweme_id"),
-                len(self._iter_gallery_items(aweme_data)),
+                len(gallery_items),
             )
         return self._deduplicate_urls(image_urls)
 

--- a/core/downloader_base.py
+++ b/core/downloader_base.py
@@ -485,7 +485,11 @@ class BaseDownloader(ABC):
     _GALLERY_AWEME_TYPES = {2, 68, 150}
 
     def _detect_media_type(self, aweme_data: Dict[str, Any]) -> str:
-        if aweme_data.get("image_post_info") or aweme_data.get("images"):
+        if (
+            aweme_data.get("image_post_info")
+            or aweme_data.get("images")
+            or aweme_data.get("image_list")
+        ):
             return "gallery"
         aweme_type = aweme_data.get("aweme_type")
         if isinstance(aweme_type, int) and aweme_type in self._GALLERY_AWEME_TYPES:

--- a/core/downloader_base.py
+++ b/core/downloader_base.py
@@ -317,8 +317,21 @@ class BaseDownloader(ABC):
         elif media_type == "gallery":
             image_urls = self._collect_image_urls(aweme_data)
             image_live_urls = self._collect_image_live_urls(aweme_data)
+            logger.info(
+                "Gallery aweme %s: %d image(s), %d live photo(s)",
+                aweme_id,
+                len(image_urls),
+                len(image_live_urls),
+            )
             if not image_urls and not image_live_urls:
-                logger.error("No gallery assets found (images/live) for aweme %s", aweme_id)
+                logger.error(
+                    "No gallery assets found for aweme %s (aweme_type=%s, "
+                    "has image_post_info=%s, has images=%s)",
+                    aweme_id,
+                    aweme_data.get("aweme_type"),
+                    "image_post_info" in aweme_data,
+                    "images" in aweme_data,
+                )
                 return False
 
             for index, image_url in enumerate(image_urls, start=1):
@@ -468,8 +481,19 @@ class BaseDownloader(ABC):
             )
             return False
 
+    # aweme_type codes that indicate image/note content
+    _GALLERY_AWEME_TYPES = {2, 68, 150}
+
     def _detect_media_type(self, aweme_data: Dict[str, Any]) -> str:
         if aweme_data.get("image_post_info") or aweme_data.get("images"):
+            return "gallery"
+        aweme_type = aweme_data.get("aweme_type")
+        if isinstance(aweme_type, int) and aweme_type in self._GALLERY_AWEME_TYPES:
+            logger.info(
+                "Detected gallery via aweme_type=%s for aweme %s",
+                aweme_type,
+                aweme_data.get("aweme_id"),
+            )
             return "gallery"
         return "video"
 
@@ -525,15 +549,24 @@ class BaseDownloader(ABC):
         for item in self._iter_gallery_items(aweme_data):
             if not isinstance(item, dict):
                 continue
+            # 优先拿可下载/原图字段，避免 preview/display 图链签名失效后整组图文失败。
+            # 同时兼容旧格式 download_url_list（直接 list）和新格式 download_url（dict with url_list）。
             image_url = self._pick_first_media_url(
+                item.get("download_url"),
+                item.get("download_addr"),
+                item.get("download_url_list"),
                 item,
                 item.get("display_image"),
                 item.get("owner_watermark_image"),
-                item.get("download_url"),
-                item.get("download_addr"),
             )
             if image_url:
                 image_urls.append(image_url)
+        if not image_urls:
+            logger.warning(
+                "No image URLs extracted for aweme %s; gallery items count=%d",
+                aweme_data.get("aweme_id"),
+                len(self._iter_gallery_items(aweme_data)),
+            )
         return self._deduplicate_urls(image_urls)
 
     def _collect_image_live_urls(self, aweme_data: Dict[str, Any]) -> List[str]:
@@ -555,10 +588,12 @@ class BaseDownloader(ABC):
     @staticmethod
     def _iter_gallery_items(aweme_data: Dict[str, Any]) -> List[Any]:
         image_post = aweme_data.get("image_post_info")
-        image_post_images = (
-            image_post.get("images") if isinstance(image_post, dict) else None
-        )
-        images = image_post_images or aweme_data.get("images") or []
+        if isinstance(image_post, dict):
+            for key in ("images", "image_list"):
+                candidate = image_post.get(key)
+                if isinstance(candidate, list) and candidate:
+                    return candidate
+        images = aweme_data.get("images") or aweme_data.get("image_list") or []
         if isinstance(images, list):
             return images
         return []

--- a/tests/test_video_downloader.py
+++ b/tests/test_video_downloader.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
@@ -619,3 +620,122 @@ async def test_download_aweme_assets_gallery_fails_when_live_video_download_fail
     assert any(path.name.endswith("_live_2.mp4") for path in saved_paths)
 
     await api_client.close()
+
+
+def test_detect_media_type_by_aweme_type(tmp_path):
+    """aweme_type 2/68/150 should be detected as gallery even without images key."""
+    downloader, api_client = _build_downloader(tmp_path)
+
+    for aweme_type in (2, 68, 150):
+        assert downloader._detect_media_type({"aweme_type": aweme_type}) == "gallery"
+
+    assert downloader._detect_media_type({"aweme_type": 4}) == "video"
+    assert downloader._detect_media_type({"aweme_type": 0}) == "video"
+    assert downloader._detect_media_type({}) == "video"
+
+    asyncio.run(api_client.close())
+
+
+def test_collect_image_urls_old_format_url_list(tmp_path):
+    """Old format: items have url_list directly."""
+    downloader, api_client = _build_downloader(tmp_path)
+
+    aweme_data = {
+        "aweme_id": "100001",
+        "images": [
+            {"url_list": ["https://example.com/img1.webp"]},
+            {"url_list": ["https://example.com/img2.webp"]},
+        ],
+    }
+
+    urls = downloader._collect_image_urls(aweme_data)
+    assert urls == [
+        "https://example.com/img1.webp",
+        "https://example.com/img2.webp",
+    ]
+
+    asyncio.run(api_client.close())
+
+
+def test_collect_image_urls_old_format_download_url_list(tmp_path):
+    """Old format: items have download_url_list (list) directly."""
+    downloader, api_client = _build_downloader(tmp_path)
+
+    aweme_data = {
+        "aweme_id": "100002",
+        "images": [
+            {
+                "url_list": ["https://example.com/preview1.webp"],
+                "download_url_list": ["https://example.com/download1.webp"],
+            },
+        ],
+    }
+
+    urls = downloader._collect_image_urls(aweme_data)
+    # download_url_list should be preferred over url_list
+    assert urls == ["https://example.com/download1.webp"]
+
+    asyncio.run(api_client.close())
+
+
+def test_collect_image_urls_new_format_download_url_preferred(tmp_path):
+    """New format: download_url dict is preferred over display_image."""
+    downloader, api_client = _build_downloader(tmp_path)
+
+    aweme_data = {
+        "aweme_id": "100003",
+        "image_post_info": {
+            "images": [
+                {
+                    "download_url": {
+                        "url_list": ["https://cdn.example.com/download.webp"]
+                    },
+                    "display_image": {
+                        "url_list": ["https://cdn.example.com/display.webp"]
+                    },
+                },
+            ]
+        },
+    }
+
+    urls = downloader._collect_image_urls(aweme_data)
+    assert urls == ["https://cdn.example.com/download.webp"]
+
+    asyncio.run(api_client.close())
+
+
+def test_iter_gallery_items_image_list_key(tmp_path):
+    """Some responses use image_list instead of images."""
+    downloader, api_client = _build_downloader(tmp_path)
+
+    aweme_data = {
+        "aweme_id": "100004",
+        "image_post_info": {
+            "image_list": [
+                {"display_image": {"url_list": ["https://example.com/img.webp"]}}
+            ]
+        },
+    }
+
+    items = downloader._iter_gallery_items(aweme_data)
+    assert len(items) == 1
+    assert items[0]["display_image"]["url_list"][0] == "https://example.com/img.webp"
+
+    asyncio.run(api_client.close())
+
+
+def test_iter_gallery_items_top_level_image_list(tmp_path):
+    """Fallback: top-level image_list key."""
+    downloader, api_client = _build_downloader(tmp_path)
+
+    aweme_data = {
+        "aweme_id": "100005",
+        "image_list": [
+            {"url_list": ["https://example.com/top.webp"]}
+        ],
+    }
+
+    items = downloader._iter_gallery_items(aweme_data)
+    assert len(items) == 1
+
+    asyncio.run(api_client.close())


### PR DESCRIPTION
## Summary
- Detect gallery content via `aweme_type` field (2/68/150) as fallback when `image_post_info`/`images` keys are missing from API response
- Support `image_list` key in addition to `images` (both in `image_post_info` and top-level) for broader API response compatibility
- Add `download_url_list` (direct list format) extraction for old-style API responses
- Reorder image URL priority: `download_url` > `download_addr` > `download_url_list` > `item.url_list` > `display_image`, preferring stable download links over expiring preview/display URLs
- Add diagnostic logging when gallery asset extraction fails

## Test plan
- [x] 6 new unit tests covering all edge cases (aweme_type detection, old/new format URL extraction, image_list fallback)
- [x] All 128 existing tests still pass
- [ ] Manual test with real `/note/` URL (e.g. `https://www.douyin.com/note/7450840636439252263`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the robustness of gallery/note downloading in `douyin-downloader` by adding multiple fallback mechanisms. It introduces `aweme_type` codes `{2, 68, 150}` as a secondary gallery-detection signal when `image_post_info`/`images` keys are absent, adds support for the `image_list` key variant (both nested inside `image_post_info` and at the top level of `aweme_data`), supports old-style `download_url_list` (a direct URL list), reorders URL priority to prefer stable download links over expiring preview URLs, and adds diagnostic logging to aid debugging when asset extraction fails. Six new unit tests cover all new code paths.\n\n**Key changes:**\n- `_detect_media_type`: falls back to `aweme_type ∈ {2, 68, 150}` when structural keys are absent\n- `_iter_gallery_items`: checks both `\"images\"` and `\"image_list\"` in `image_post_info`, and falls back to top-level `aweme_data[\"image_list\"]`\n- `_collect_image_urls`: URL priority reordered to `download_url` → `download_addr` → `download_url_list` → `item.url_list` → `display_image` → `owner_watermark_image`\n- **Minor gap**: `_detect_media_type` does not check the top-level `image_list` key, so an aweme with only `image_list` (no `image_post_info`/`images` and `aweme_type` outside `{2, 68, 150}`) would still be misclassified as video\n- **Minor inefficiency**: `_iter_gallery_items` is invoked a second time in the warning-log path inside `_collect_image_urls`

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style/consistency suggestions that do not block the primary download path.

All issues found are P2: a small inconsistency between _detect_media_type and _iter_gallery_items for the top-level image_list key, and a minor double-call inefficiency in _collect_image_urls. Neither constitutes a runtime defect on any of the targeted API response formats. The new tests are correct and cover the intended edge cases; existing 128 tests still pass per the PR description.

core/downloader_base.py — minor inconsistency in _detect_media_type not checking top-level image_list

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/downloader_base.py | Core gallery detection and URL extraction logic updated: adds aweme_type fallback detection, image_list key support, reorders URL priority to prefer stable download links, and improves diagnostic logging; minor inconsistency in _detect_media_type not checking top-level image_list. |
| tests/test_video_downloader.py | 6 new synchronous unit tests added covering aweme_type detection, old/new URL format extraction, and image_list fallback; all test cases are logically sound and correctly use asyncio.run to close async resources. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[aweme_data] --> B{_detect_media_type}
    B -->|image_post_info or images present| C[gallery]
    B -->|aweme_type in 2/68/150| C
    B -->|otherwise| D[video]

    C --> E[_collect_image_urls]
    E --> F[_iter_gallery_items]
    F -->|image_post_info.images| G[items list]
    F -->|image_post_info.image_list NEW| G
    F -->|aweme_data.images| G
    F -->|aweme_data.image_list NEW| G

    G --> H{Per item: _pick_first_media_url}
    H -->|1st priority| I[download_url dict]
    H -->|2nd priority| J[download_addr dict]
    H -->|3rd priority NEW| K[download_url_list list]
    H -->|4th priority| L[item.url_list]
    H -->|5th priority| M[display_image]
    H -->|6th priority| N[owner_watermark_image]

    H --> O[image_urls list]
    O -->|empty| P[Warning log with diagnostic info]
    O --> Q[_deduplicate_urls]
```

<sub>Reviews (1): Last reviewed commit: ["fix: improve note/gallery download robus..."](https://github.com/jiji262/douyin-downloader/commit/fa1d382b3936600e6cd4e42e3ff73f016b7623c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26547063)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->