### PR TITLE
fix(notifier): restore correct WebhookProvider (NameError on every call)

### DIFF
--- a/utils/notifier.py
+++ b/utils/notifier.py
@@ -119,12 +119,12 @@ class WebhookProvider(_BaseProvider):
         url = str(self.settings.get("url") or "")
         if not url:
             logger.warning("Webhook notification skipped: missing url")
-        text = f"<b>{title}</b>\n{body}" if title else body
-        payload = {
-            "chat_id": chat_id,
-            "text": text,
-            "parse_mode": "HTML",
+            return False
+        extra_headers = {
+            str(k): str(v) for k, v in (self.settings.get("headers") or {}).items()
         }
+        payload: Dict[str, Any] = {"title": title, "body": body, "level": level}
+        # 允许通过 extra_body 合并到 payload，便于适配某些平台（企业微信 msgtype 等）。
         extra_body = self.settings.get("extra_body")
         if isinstance(extra_body, dict):
             payload.update(extra_body)


### PR DESCRIPTION
## Summary

Commit [d71c2f3](https://github.com/jiji262/douyin-downloader/commit/d71c2f3) (\"Update utils/notifier.py\") replaced the `WebhookProvider.send` body with Telegram-shaped code that referenced two **undefined** names and dropped the early-return on missing URL. Every webhook notification therefore raised `NameError`.

## Repro

```python
from utils.notifier import WebhookProvider
import aiohttp, asyncio
async def go():
    p = WebhookProvider({'url': 'https://example.com/hook'})
    async with aiohttp.ClientSession() as s:
        await p.send(s, title='t', body='b', level='info')
asyncio.run(go())
# NameError: name 'chat_id' is not defined
```

The tests `test_webhook_provider_posts_json` and `test_webhook_provider_reports_failure_on_4xx` (both pre-existing) have been failing on `main` since `d71c2f3` landed.

## Fix

Restore the three things the commit broke:

| Regression | Fix |
|---|---|
| Missing `return False` after \"missing url\" warning | Re-add the early return |
| `extra_headers` removed | Re-derive from `self.settings["headers"]` |
| Webhook payload replaced with Telegram-shaped `{chat_id, text, parse_mode}` using undefined `chat_id` | Restore `{title, body, level}` shape (documented contract; `extra_body` already merges in platform-specific keys for 企业微信/飞书/钉钉) |

Diff is a 5-line swap within a single function.

## Test plan

- [x] `.venv/bin/python -m pytest tests/ -q` → **175 passed** (was 173 passed, 2 failed)
- [x] Import smoke: `from utils.notifier import WebhookProvider` OK
- [x] `python -m compileall` clean
- [x] No behavior change for Bark/Telegram providers

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a targeted regression fix for `WebhookProvider.send` in `utils/notifier.py`. The broken commit (`d71c2f3`) had replaced the webhook implementation with Telegram-shaped code that referenced undefined names (`chat_id`) and dropped the early-return guard, causing a `NameError` on every webhook notification. The fix restores the three missing pieces: the `return False` guard, `extra_headers` derivation, and the documented `{title, body, level}` payload shape.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, well-scoped regression fix with no new logic and full test coverage.

All three regressions introduced in d71c2f3 are correctly addressed. The diff is a 5-line swap within a single function, no other behaviour changes, and the test suite now passes (175 passed vs 173 passed + 2 failed). No new issues found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| utils/notifier.py | Restores the correct WebhookProvider.send body: re-adds early return on missing URL, re-derives extra_headers from settings, and restores the documented {title, body, level} payload — fixing the NameError introduced in d71c2f3. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant WebhookProvider
    participant aiohttp

    Caller->>WebhookProvider: send(session, title, body, level)
    alt url is missing
        WebhookProvider-->>Caller: logger.warning + return False
    else url present
        WebhookProvider->>WebhookProvider: build extra_headers from settings["headers"]
        WebhookProvider->>WebhookProvider: build payload = {title, body, level}
        WebhookProvider->>WebhookProvider: merge extra_body if dict
        WebhookProvider->>aiohttp: POST url, json=payload, headers=extra_headers
        aiohttp-->>WebhookProvider: HTTP response
        alt status < 400
            WebhookProvider-->>Caller: return True
        else status >= 400
            WebhookProvider->>WebhookProvider: logger.warning
            WebhookProvider-->>Caller: return False
        end
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(notifier): restore correct WebhookPr..."](https://github.com/jiji262/douyin-downloader/commit/0d25332560cd483ad56c5c00c1d1114d33da76bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29578702)</sub>

<!-- /greptile_comment -->