### PR TITLE
fix: null payload fields, inclusive end_time filter, content-encoded downloads

### DIFF
--- a/core/downloader_base.py
+++ b/core/downloader_base.py
@@ -1,7 +1,7 @@
 import json
 import re
 from abc import ABC, abstractmethod
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Protocol, Tuple
 from urllib.parse import urlparse
@@ -230,9 +230,11 @@ class BaseDownloader(ABC):
         # a user asking for ``end_time=2024-01-31`` wants everything published
         # *on* Jan 31 too. ``strptime`` lands on 00:00:00, so extend the bound
         # to the last second of that day; otherwise every post after midnight
-        # on the end date is silently dropped.
+        # on the end date is silently dropped. Use ``timedelta(days=1)`` rather
+        # than ``+ 86400`` so ``.timestamp()`` accounts for the actual day
+        # length across DST transitions (a spring-forward day is only 23h).
         end_ts = (
-            int(datetime.strptime(end_time, "%Y-%m-%d").timestamp()) + 86400 - 1
+            int((datetime.strptime(end_time, "%Y-%m-%d") + timedelta(days=1)).timestamp()) - 1
             if end_time
             else None
         )

--- a/core/downloader_base.py
+++ b/core/downloader_base.py
@@ -226,7 +226,16 @@ class BaseDownloader(ABC):
         start_ts = (
             int(datetime.strptime(start_time, "%Y-%m-%d").timestamp()) if start_time else None
         )
-        end_ts = int(datetime.strptime(end_time, "%Y-%m-%d").timestamp()) if end_time else None
+        # ``end_time`` is a date (``YYYY-MM-DD``) and the filter is inclusive:
+        # a user asking for ``end_time=2024-01-31`` wants everything published
+        # *on* Jan 31 too. ``strptime`` lands on 00:00:00, so extend the bound
+        # to the last second of that day; otherwise every post after midnight
+        # on the end date is silently dropped.
+        end_ts = (
+            int(datetime.strptime(end_time, "%Y-%m-%d").timestamp()) + 86400 - 1
+            if end_time
+            else None
+        )
 
         filtered: List[Dict[str, Any]] = []
         for aweme in aweme_list:
@@ -338,7 +347,10 @@ class BaseDownloader(ABC):
                         downloaded_files.append(cover_path)
 
             if self.config.get("music"):
-                music_url = self._extract_first_url(aweme_data.get("music", {}).get("play_url"))
+                # ``music`` is frequently an explicit ``null`` in real payloads
+                # (original sound removed, some reposts). ``get(k, {})`` only
+                # defaults on a missing key, not on ``None`` — use ``or {}``.
+                music_url = self._extract_first_url((aweme_data.get("music") or {}).get("play_url"))
                 if music_url:
                     music_path = save_dir / f"{file_stem}_music.mp3"
                     if await self._download_with_retry(
@@ -410,7 +422,7 @@ class BaseDownloader(ABC):
             return False
 
         if self.config.get("avatar"):
-            author = aweme_data.get("author", {})
+            author = aweme_data.get("author") or {}
             avatar_source = author.get("avatar_larger")
             if self._extract_urls(avatar_source):
                 avatar_path = save_dir / f"{file_stem}_avatar.jpg"
@@ -444,7 +456,7 @@ class BaseDownloader(ABC):
             if saved is not None:
                 downloaded_files.append(comments_path)
 
-        author = aweme_data.get("author", {})
+        author = aweme_data.get("author") or {}
         if self.database:
             metadata_json = json.dumps(aweme_data, ensure_ascii=False)
             cover = (aweme_data.get("video") or {}).get("cover") or {}
@@ -623,7 +635,10 @@ class BaseDownloader(ABC):
     def _build_no_watermark_url(
         self, aweme_data: Dict[str, Any]
     ) -> Optional[Tuple[str, Dict[str, str]]]:
-        video = aweme_data.get("video", {})
+        # ``video`` can be an explicit ``null`` (not just missing) for note
+        # posts and some reposts; ``get(k, {})`` wouldn't guard that and the
+        # ``video.get(...)`` fallbacks below would raise AttributeError.
+        video = aweme_data.get("video") or {}
         quality = str(self.config.get("video_quality") or "highest")
         play_addr = self._pick_preferred_play_addr(video, quality) or {}
         url_candidates = [c for c in (play_addr.get("url_list") or []) if c]

--- a/storage/file_manager.py
+++ b/storage/file_manager.py
@@ -206,7 +206,9 @@ class FileManager:
                     return await self._persist_stream(
                         response.content.iter_chunked(8192),
                         save_path,
-                        response.content_length,
+                        self._expected_size_from_headers(
+                            response.headers, response.content_length
+                        ),
                         response.headers,
                         prefer_response_content_type=prefer_response_content_type,
                         return_saved_path=return_saved_path,
@@ -233,6 +235,29 @@ class FileManager:
         finally:
             if should_close:
                 await session.close()
+
+    @staticmethod
+    def _expected_size_from_headers(response_headers, content_length) -> Optional[int]:
+        """Return the byte count to validate the download against, or ``None``.
+
+        Both aiohttp and httpx transparently decompress the response body, so a
+        ``Content-Length`` header (which reflects the *compressed* size) can't be
+        compared against the decompressed bytes we actually write. When
+        ``Content-Encoding`` is present we skip the size check entirely;
+        otherwise we trust ``content_length``.
+
+        Defensive against mock/non-dict headers: only a real, non-empty string
+        encoding disables the check.
+        """
+        encoding = None
+        if response_headers is not None:
+            try:
+                encoding = response_headers.get("Content-Encoding")
+            except (AttributeError, TypeError):
+                encoding = None
+        if isinstance(encoding, str) and encoding.strip():
+            return None
+        return content_length
 
     async def _persist_stream(
         self,
@@ -300,16 +325,16 @@ class FileManager:
                         )
                         return False
                     # httpx auto-decompresses; Content-Length is the *compressed*
-                    # size, so only trust it when the body isn't encoded.
-                    expected_size: Optional[int] = None
-                    if not response.headers.get("Content-Encoding"):
-                        content_length = response.headers.get("Content-Length")
-                        if content_length is not None and content_length.isdigit():
-                            expected_size = int(content_length)
+                    # size, so only trust it when the body isn't encoded (shared
+                    # guard with the aiohttp path).
+                    raw_length = response.headers.get("Content-Length")
+                    parsed_length = (
+                        int(raw_length) if raw_length is not None and raw_length.isdigit() else None
+                    )
                     return await self._persist_stream(
                         response.aiter_bytes(),
                         save_path,
-                        expected_size,
+                        self._expected_size_from_headers(response.headers, parsed_length),
                         response.headers,
                         prefer_response_content_type=prefer_response_content_type,
                         return_saved_path=return_saved_path,

--- a/tests/test_downloader_reliability.py
+++ b/tests/test_downloader_reliability.py
@@ -1,0 +1,90 @@
+"""Regression tests for download reliability against real-world payloads.
+
+Covers:
+  * null-safe handling of ``music`` / ``video`` / ``author`` fields that
+    Douyin frequently serves as an explicit JSON ``null`` (not just missing);
+  * the inclusive ``end_time`` date filter (the end day must be kept).
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _build_video_downloader(tmp_path):
+    from auth import CookieManager
+    from config import ConfigLoader
+    from control import QueueManager, RateLimiter, RetryHandler
+    from core.api_client import DouyinAPIClient
+    from core.video_downloader import VideoDownloader
+    from storage import FileManager
+
+    config = ConfigLoader()
+    config.update(path=str(tmp_path))
+    return VideoDownloader(
+        config,
+        DouyinAPIClient({}),
+        FileManager(str(tmp_path)),
+        CookieManager(str(tmp_path / ".cookies.json")),
+        database=None,
+        rate_limiter=RateLimiter(max_per_second=5),
+        retry_handler=RetryHandler(max_retries=1),
+        queue_manager=QueueManager(max_workers=1),
+    )
+
+
+def test_build_no_watermark_url_handles_null_video(tmp_path):
+    """A payload with ``"video": null`` must resolve to "no URL" (None) rather
+    than raising AttributeError on the ``video.get(...)`` fallbacks."""
+    downloader = _build_video_downloader(tmp_path)
+    assert downloader._build_no_watermark_url({"video": None}) is None
+
+
+@pytest.mark.asyncio
+async def test_download_assets_survives_null_music_and_author(tmp_path):
+    """``music`` and ``author`` are commonly ``null`` in real payloads. The
+    asset pipeline must download the video and finish cleanly instead of
+    crashing after the media already landed on disk."""
+    downloader = _build_video_downloader(tmp_path)
+    downloader.config.update(cover=False, json=False, avatar=True, music=True)
+
+    # Isolate from real network / disk side effects.
+    downloader.file_manager.download_file = AsyncMock(return_value=True)
+    downloader.metadata_handler.append_download_manifest = AsyncMock(return_value=None)
+    downloader.api_client.get_session = AsyncMock(return_value=MagicMock())
+
+    aweme_data = {
+        "aweme_id": "7123456789012345678",
+        "desc": "hello world",
+        "create_time": 1700000000,
+        "video": {
+            "play_addr": {"uri": "v1", "url_list": ["https://cdn.example.com/v.mp4"]}
+        },
+        "music": None,
+        "author": None,
+    }
+
+    result = await downloader._download_aweme_assets(aweme_data, "unknown")
+    assert result is True
+    downloader.file_manager.download_file.assert_awaited()
+
+
+def test_filter_by_time_end_date_is_inclusive(tmp_path):
+    """``end_time`` is a date; the whole end day must be kept. A post at noon
+    on the end date used to be dropped because the bound was midnight."""
+    downloader = _build_video_downloader(tmp_path)
+    downloader.config.update(start_time="2024-01-31", end_time="2024-01-31")
+
+    on_end_day = int(datetime(2024, 1, 31, 12, 0, 0).timestamp())
+    before_start = int(datetime(2024, 1, 30, 12, 0, 0).timestamp())
+    after_end = int(datetime(2024, 2, 1, 0, 30, 0).timestamp())
+
+    items = [
+        {"aweme_id": "a", "create_time": on_end_day},
+        {"aweme_id": "b", "create_time": before_start},
+        {"aweme_id": "c", "create_time": after_end},
+    ]
+
+    filtered = downloader._filter_by_time(items)
+    assert [i["aweme_id"] for i in filtered] == ["a"]

--- a/tests/test_file_manager.py
+++ b/tests/test_file_manager.py
@@ -395,6 +395,42 @@ async def test_download_file_no_httpx_fallback_on_404(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_download_file_keeps_content_encoded_body(tmp_path):
+    """aiohttp transparently decompresses the body, but ``content_length``
+    reflects the *compressed* ``Content-Length`` header. A gzip/br response
+    must NOT be discarded as a size mismatch — otherwise a perfectly good
+    download is deleted and reported as a failure."""
+    fm = FileManager(str(tmp_path))
+    save_path = tmp_path / "data.mp4"
+    decompressed = b"the fully decompressed body, longer than the compressed header"
+
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.content_length = 12  # compressed size from Content-Length
+    mock_response.headers = {"Content-Encoding": "gzip"}
+
+    async def iter_chunked(size):
+        yield decompressed
+
+    mock_response.content = MagicMock()
+    mock_response.content.iter_chunked = iter_chunked
+
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=mock_response)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = MagicMock()
+    mock_session.get.return_value = ctx
+
+    result = await fm.download_file(
+        "https://example.com/data.mp4", save_path, session=mock_session
+    )
+    assert result is True
+    assert save_path.exists()
+    assert save_path.read_bytes() == decompressed
+
+
+@pytest.mark.asyncio
 async def test_download_file_size_mismatch_cleans_up(tmp_path):
     fm = FileManager(str(tmp_path))
     save_path = tmp_path / "video.mp4"


### PR DESCRIPTION
## What & why

Three small, independent download-reliability / correctness fixes found while reviewing the core download path against real-world Douyin payloads. Each has a regression test.

### 1. Crash on `null` payload fields (`core/downloader_base.py`)
Douyin regularly serves `music`, `video` and `author` as an **explicit JSON `null`** (original sound removed, note posts, some reposts) — not just a missing key. `dict.get(k, {})` only substitutes the default when the key is *absent*, so:

```python
aweme_data.get("music", {}).get("play_url")   # AttributeError when music is null
```

raises `AttributeError: 'NoneType' object has no attribute 'get'`. This is uncaught in `_download_aweme_assets`, so it fails the **whole** aweme. For the DB/manifest write (`author`) it fires *after* the media already downloaded, so the file lands on disk but the item is still reported as failed.

Fixed the `music`, `video` (in `_build_no_watermark_url`), and `author` (avatar + DB/manifest) sites to use the `... or {}` idiom already used a few lines away (e.g. `cover = (aweme_data.get("video") or {}).get("cover") or {}`).

### 2. `end_time` filter is off-by-one (`core/downloader_base.py`)
`end_time` is a `YYYY-MM-DD` date and the filter is inclusive, but `strptime` lands on `00:00:00`, and the filter drops `create_time > end_ts`. So **every post published after midnight on the end date is silently dropped** — asking for `end_time=2024-01-31` returns nothing from Jan 31. `start_time` is inclusive, making the range asymmetric. Extended the end bound to the last second of that day (`+ 86400 - 1`).

### 3. aiohttp deletes valid content-encoded downloads (`storage/file_manager.py`)
aiohttp transparently decompresses the body that `iter_chunked` yields, but `response.content_length` reflects the compressed `Content-Length` header. For any gzip/deflate/br response the written (decompressed) size won't match, so the size-mismatch guard **deletes a perfectly good download and reports failure**. The httpx path already guarded exactly this — extracted the logic into a shared `_expected_size_from_headers` helper and applied it to both paths.

## Tests
- `tests/test_downloader_reliability.py` (new): null `video` → no crash; null `music`/`author` asset pipeline completes; `end_time` inclusive of the end day.
- `tests/test_file_manager.py`: content-encoded body is kept rather than deleted.

Tests follow the existing mock/fixture patterns in the suite. Run with `python -m pytest tests/`.

## Note for maintainers
`core/downloader_base.py` and `storage/file_manager.py` are listed in `AGENTS.md` as shared with the desktop sibling — these fixes should be synced there to avoid drift.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Three targeted reliability fixes for the core download path: null-safe field access for `music`, `video`, and `author` payloads; an inclusive `end_time` date filter; and a shared `_expected_size_from_headers` helper that prevents aiohttp from deleting valid content-encoded downloads. Each fix has a paired regression test.

- **Null safety** (`core/downloader_base.py`): Four `dict.get(k, {})` call-sites that silently fail when Douyin returns an explicit JSON `null` are replaced with the `... or {}` idiom already used elsewhere in the same file.
- **`end_time` inclusivity** (`core/downloader_base.py`): The end-of-day bound is extended to 23:59:59 of the specified date so the entire end day is included in the filter.
- **Content-encoded size guard** (`storage/file_manager.py`): The httpx-only `Content-Encoding` check is extracted into `_expected_size_from_headers` and applied to the aiohttp path as well, preventing the size-mismatch guard from deleting transparently-decompressed responses.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all three fixes address real-world failures with clear, targeted changes and regression tests.

The end_ts computation uses a fixed 86399-second offset rather than timedelta(days=1), which can overshoot by up to an hour on DST spring-forward days. The residual get(video, {}) call in the cover block is safe due to the early-return guard but inconsistent with the other null-safety fixes in this PR.

core/downloader_base.py — both the DST note on the end_ts bound and the leftover get(video, {}) in the cover block are worth a second look before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| core/downloader_base.py | Fixes null-payload crashes for `music`, `video`, and `author` fields, and corrects inclusive `end_time` bound using `+86400-1`. One residual `get("video", {})` in the cover-download block is inconsistent with the other null-safety fixes, and the magic-number DST approach could overshoot by an hour on spring-forward days. |
| storage/file_manager.py | Extracts `_expected_size_from_headers` to unify content-encoding guard across both aiohttp and httpx paths; logic is correct and behaviour-preserving for all Content-Encoding variants. |
| tests/test_downloader_reliability.py | New regression tests covering null `video`/`music`/`author` payloads and the inclusive `end_time` filter; follows existing mock/fixture patterns and correctly isolates network and disk side-effects. |
| tests/test_file_manager.py | Adds a focused test verifying that a content-encoded aiohttp response is kept rather than deleted; mock setup correctly separates compressed header from decompressed body bytes. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[download_file called] --> B{aiohttp GET}
    B -->|status 200| C[_expected_size_from_headers\naiohttp headers + content_length]
    B -->|status 403| D[_download_via_httpx]
    D --> E[_expected_size_from_headers\nhttpx headers + parsed_length]
    C --> F{Content-Encoding present?}
    E --> F
    F -->|Yes| G[expected_size = None\nskip size check]
    F -->|No| H[expected_size = content_length]
    G --> I[_persist_stream]
    H --> I
    I --> J{written == expected_size or None?}
    J -->|Yes| K[atomic rename - success]
    J -->|No| L[delete tmp file - False]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[download_file called] --> B{aiohttp GET}
    B -->|status 200| C[_expected_size_from_headers\naiohttp headers + content_length]
    B -->|status 403| D[_download_via_httpx]
    D --> E[_expected_size_from_headers\nhttpx headers + parsed_length]
    C --> F{Content-Encoding present?}
    E --> F
    F -->|Yes| G[expected_size = None\nskip size check]
    F -->|No| H[expected_size = content_length]
    G --> I[_persist_stream]
    H --> I
    I --> J{written == expected_size or None?}
    J -->|Yes| K[atomic rename - success]
    J -->|No| L[delete tmp file - False]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `core/downloader_base.py`, line 337 ([link](https://github.com/jiji262/douyin-downloader/blob/1f12b64d75ec57043ad72b380b76616b3221f545/core/downloader_base.py#L337)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> This cover access still uses the old `get("video", {})` idiom, which doesn't guard against an explicit `null`. In practice it is safe here because `_build_no_watermark_url` would have returned `None` (and the function exited early) if `video` were `null`. But it's inconsistent with the other null-safety fixes applied in this PR — making it `or {}` keeps the whole file uniform and removes the latent trap if the guard ever moves.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: guard null payload fields, inclusiv..."](https://github.com/jiji262/douyin-downloader/commit/1f12b64d75ec57043ad72b380b76616b3221f545) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41369692)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->