### PR TITLE
fix: 修复用户合集拉取字段不匹配及古老视频播放直链 403 下载失败问题

### DIFF
--- a/core/api_client.py
+++ b/core/api_client.py
@@ -293,7 +293,7 @@ class DouyinAPIClient:
     ) -> Dict[str, Any]:
         raw = raw_data if isinstance(raw_data, dict) else {}
         keys = item_keys or []
-        keys = ["items", *keys, "aweme_list", "mix_list", "music_list"]
+        keys = [*keys, "items", "aweme_list", "mix_list", "music_list"]
 
         items: List[Dict[str, Any]] = []
         for key in keys:

--- a/core/api_client.py
+++ b/core/api_client.py
@@ -434,7 +434,7 @@ class DouyinAPIClient:
     ) -> Dict[str, Any]:
         params = await self._build_user_page_params(sec_uid, max_cursor, count)
         raw = await self._request_json("/aweme/v1/web/mix/list/", params)
-        return self._normalize_paged_response(raw, item_keys=["mix_list"])
+        return self._normalize_paged_response(raw, item_keys=["mix_infos", "mix_list"])
 
     async def get_user_music(
         self, sec_uid: str, max_cursor: int = 0, count: int = 20

--- a/core/downloader_base.py
+++ b/core/downloader_base.py
@@ -732,20 +732,22 @@ class BaseDownloader(ABC):
             is_watermarked = self._is_watermarked_media_url(candidate)
 
             if parsed.netloc.endswith("douyin.com"):
-                if "X-Bogus=" not in candidate:
-                    signed_url, ua = self.api_client.sign_url(candidate)
-                    headers = self._download_headers(user_agent=ua)
-                    if is_watermarked:
-                        watermarked_candidate = watermarked_candidate or (
-                            signed_url,
-                            headers,
-                        )
-                        continue
-                    return signed_url, headers
+                clean_url = candidate
+                if "X-Bogus=" in candidate:
+                    from urllib.parse import parse_qsl, urlencode, urlunparse
+                    parsed_cand = urlparse(candidate)
+                    qsl = [(k, v) for k, v in parse_qsl(parsed_cand.query) if k != "X-Bogus"]
+                    clean_url = urlunparse(parsed_cand._replace(query=urlencode(qsl)))
+
+                signed_url, ua = self.api_client.sign_url(clean_url)
+                headers = self._download_headers(user_agent=ua)
                 if is_watermarked:
-                    watermarked_candidate = watermarked_candidate or (candidate, headers)
+                    watermarked_candidate = watermarked_candidate or (
+                        signed_url,
+                        headers,
+                    )
                     continue
-                return candidate, headers
+                return signed_url, headers
 
             if is_watermarked:
                 watermarked_candidate = watermarked_candidate or (candidate, headers)


### PR DESCRIPTION
### 1. 字段适配问题
- 抖音 API 将合集列表的返回字段从原先的 mix_list 变更为新的 mix_infos，导致原本只匹配 mix_list 的代码解析出空合集。
- 修复方法：在 get_user_mix 解析列表中同时兼容 mix_infos 与 mix_list 字段。

### 2. 古老视频直链 403 Forbidden 报错问题
- 2025 年及以前的古老视频没有普通 CDN 直链，只能回退使用 www.douyin.com/aweme/v1/play/ 播放端点进行下载。
- 原接口数据中已经硬编码包含了旧的 X-Bogus 签名，原程序发现含 X-Bogus 便没有重新签名，而是直接用当前 API 随机生成的 User-Agent 去下载，导致 X-Bogus 与下载时 UA 不匹配触发 403 错误。
- 修复方法：遇到 douyin.com 主域名播放直链时，统一剔除原链接中自带的旧 X-Bogus，并强制使用匹配我们当前 UA 的全新 X-Bogus 重新签名下载。

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates Douyin mix parsing and play URL signing. The main changes are:

- Accept `mix_infos` as a user mix list field.
- Keep `mix_list` as the legacy fallback field.
- Strip stale `X-Bogus` from Douyin play URLs before re-signing downloads.

<h3>Confidence Score: 4/5</h3>

The changed Douyin play URL signing path needs a small fix before merging.

- The mix-list field fallback looks compatible with the existing normalization flow.
- The download fallback can still return 403 when query cleanup rewrites valid play URL parameters before signing.

core/downloader_base.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/api_client.py | Adds `mix_infos` before `mix_list` in user mix response normalization. |
| core/downloader_base.py | Re-signs Douyin-hosted play URLs after removing stale `X-Bogus`, but the query cleanup can alter the signed URL string. |

<sub>Reviews (1): Last reviewed commit: ["fix: 修复用户合集拉取字段不匹配及古老视频播放直链 403 下载失败问题"](https://github.com/jiji262/douyin-downloader/commit/6c257c767b29abb05620bbc7f85ca9329f47ea52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43591474)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->