### PR TITLE
fix: 修复用户主页批量下载合集时无法按合集名字分子目录的问题

### DIFF
--- a/core/user_downloader.py
+++ b/core/user_downloader.py
@@ -238,8 +238,9 @@ class UserDownloader(BaseDownloader):
                 self._progress_advance_item(status, str(aweme_id or "unknown"))
                 return {"status": status, "aweme_id": aweme_id}
 
+            collection_dir = item.get("_collection_dir")
             success = await self._download_aweme_assets(
-                item, author_name, mode=mode, db_batch=db_batch
+                item, author_name, mode=mode, db_batch=db_batch, collection_dir=collection_dir
             )
             status = "success" if success else "failed"
             self._progress_advance_item(status, str(aweme_id or "unknown"))

--- a/core/user_modes/base_strategy.py
+++ b/core/user_modes/base_strategy.py
@@ -228,6 +228,12 @@ class BaseUserModeStrategy(ABC):
             if not entry_id:
                 continue
 
+            # 对于合集（mix），提取其合集名称作为目录
+            col_dir = None
+            if id_field == "mix_id":
+                from core.mix_downloader import derive_mix_collection_dir
+                col_dir = derive_mix_collection_dir(item, entry_id)
+
             cursor = 0
             has_more = True
             while has_more:
@@ -255,6 +261,8 @@ class BaseUserModeStrategy(ABC):
                     if not aweme_id or aweme_id in seen_aweme:
                         continue
                     seen_aweme.add(aweme_id)
+                    if col_dir:
+                        extracted["_collection_dir"] = col_dir
                     expanded.append(extracted)
 
                 has_more = bool(page.get("has_more", False))


### PR DESCRIPTION
### 问题描述
- 用户主页批量下载在 mix 模式下展开解析合集作品列表时，原程序在列表拍平合并后丢失了“这个视频属于哪一个合集名字”的关联信息，导致所有的合集视频全部被存放到了 mix/ 根目录下，没有按合集名建立子文件夹。

### 修复方法
- 在合集视频展开逻辑 (_expand_metadata_items) 中，提取每个合集的真实名称并将其作为 _collection_dir 属性注入到每一个视频的数据中。
- 多线程下载器在处理作品时，读取此 _collection_dir 属性并传给文件管理器，从而为每个合集单独创建以其命名的子文件夹。

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds collection-aware paths for expanded user mix downloads. The main changes are:

- Expanded mix items now receive a `_collection_dir` marker.
- User downloads now pass that marker into asset path creation.
- Mix collection folders are derived through the existing mix naming helper.

<h3>Confidence Score: 4/5</h3>

The changed mix expansion path can still place files in the wrong collection folders.

- Nested `mix_info` names can be ignored, causing id-based folders.
- Videos shared by multiple mixes are collapsed into one collection directory.
- The downloader-side path handoff follows the existing file-manager behavior.

core/user_modes/base_strategy.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/user_downloader.py | Forwards an optional `_collection_dir` from each item into the existing asset download path. |
| core/user_modes/base_strategy.py | Adds collection directory derivation for expanded mix items, but misses nested names and duplicate collection memberships. |

<sub>Reviews (1): Last reviewed commit: ["fix: 修复用户主页批量下载合集时无法按合集名字分子目录的问题"](https://github.com/jiji262/douyin-downloader/commit/862d526b19a5997db74413a48654bec5df999f3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43591479)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->