### PR TITLE
perf: 为 Whisper 转写添加 Mac GPU (MPS) 加速及 FP16 兼容性自适应检测

### DIFF
--- a/cli/whisper_transcribe.py
+++ b/cli/whisper_transcribe.py
@@ -347,7 +347,8 @@ def transcribe_file(
         display.advance_file("识别中", f"音频 {audio_mb:.1f}MB")
 
         # Step 2: Whisper 识别
-        result = model.transcribe(audio_path, language=language, verbose=False)
+        fp16_supported = model.device.type == "cuda"
+        result = model.transcribe(audio_path, language=language, verbose=False, fp16=fp16_supported)
         segments = result.get("segments", [])
         detected_lang = result.get("language", language)
 
@@ -496,8 +497,15 @@ def main():
     display.info(f"找到 {len(videos)} 个视频")
 
     # ── 加载模型 ──
-    display.info(f"加载 Whisper 模型: [{THEME['model']}]{args.model}[/]  (首次需下载)")
-    model = whisper.load_model(args.model)
+    import torch
+    device = "cpu"
+    if torch.cuda.is_available():
+        device = "cuda"
+    elif torch.backends.mps.is_available():
+        device = "mps"
+
+    display.info(f"加载 Whisper 模型: [{THEME['model']}]{args.model}[/] (运行设备: {device})  (首次需下载)")
+    model = whisper.load_model(args.model, device=device)
     display.success(f"模型 [{THEME['model']}]{args.model}[/] 加载完成")
     console.print()
 


### PR DESCRIPTION
### 优化描述
- 对 cli/whisper_transcribe.py 的转写逻辑进行了硬件自适应优化。
- 引入 torch 自适应检测，在加载 Whisper 模型时优先使用英伟达 GPU (cuda) 或 Apple Silicon Mac GPU (mps)，最后回退至 cpu。
- 针对 model.transcribe，自动根据当前运行的硬件环境自适应传入 fp16 参数（仅在 cuda 设备下启用 fp16=True，而在 Mac mps 或 CPU 设备下设为 False），彻底消除了在 Mac 等设备上因强行执行 FP16 推理带来的警告或运行时崩溃。
- 该修改均使用 Whisper 原生参数，完全向下兼容，未产生冲突。

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds hardware-aware Whisper transcription setup. The main changes are:

- Select CUDA, MPS, or CPU before loading the Whisper model.
- Pass the selected device into `whisper.load_model`.
- Disable Whisper `fp16` transcription unless the model is on CUDA.

<h3>Confidence Score: 4/5</h3>

The changed CLI startup path can crash instead of using CPU fallback on torch builds without an MPS backend.

- Device-aware fp16 handling looks correct for CUDA, MPS, and CPU.
- The MPS availability check assumes `torch.backends.mps` exists.
- Unsupported torch builds can fail before any transcription starts.

cli/whisper_transcribe.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cli/whisper_transcribe.py | Adds explicit Whisper device selection and CUDA-only fp16 handling; MPS detection needs a guard for torch builds without that backend. |

<sub>Reviews (1): Last reviewed commit: ["perf: 为 Whisper 转写添加 Mac GPU (MPS) 加速及 F..."](https://github.com/jiji262/douyin-downloader/commit/0654c6c308f0c29abdc655b2f269e07482d3d3c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43591956)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->