### PR TITLE
feat: collect bounded Douyin reply threads

### DIFF
--- a/core/api_client.py
+++ b/core/api_client.py
@@ -877,6 +877,21 @@ class DouyinAPIClient:
             }
         )
         raw = await self._request_json("/aweme/v1/web/comment/list/reply/", params)
+        # ``_request_json`` returns an empty mapping after anti-bot responses
+        # (for example an empty HTTP 200 body).  Do not let the collector
+        # interpret that as a valid empty reply page: preserve a non-zero
+        # status so it records ``reply_api_failed`` and reports partial data.
+        if not raw:
+            return {
+                "items": [],
+                "aweme_list": [],
+                "has_more": False,
+                "max_cursor": cursor,
+                "status_code": -1,
+                "source": "api",
+                "risk_flags": {"login_tip": False, "verify_page": False},
+                "raw": {},
+            }
         return self._normalize_paged_response(raw, item_keys=["comments"])
 
     async def resolve_short_url(

--- a/core/api_client.py
+++ b/core/api_client.py
@@ -841,6 +841,7 @@ class DouyinAPIClient:
         Returns:
             归一化后的分页响应 dict，items 为评论列表。
         """
+        del include_replies
         params = await self._default_query()
         params.update(
             {
@@ -855,24 +856,7 @@ class DouyinAPIClient:
             }
         )
         raw = await self._request_json("/aweme/v1/web/comment/list/", params)
-        normalized = self._normalize_paged_response(raw, item_keys=["comments"])
-
-        if include_replies:
-            comments = normalized.get("items") or []
-            for comment in comments:
-                if not isinstance(comment, dict):
-                    continue
-                comment_id = comment.get("cid") or comment.get("comment_id")
-                if not comment_id or int(comment.get("reply_comment_total") or 0) <= 0:
-                    continue
-                try:
-                    reply_page = await self.get_aweme_comment_replies(
-                        aweme_id=aweme_id, comment_id=str(comment_id), count=count
-                    )
-                    comment["_replies"] = reply_page.get("items") or []
-                except Exception as exc:  # noqa: BLE001
-                    logger.debug("Fetch reply for comment %s failed: %s", comment_id, exc)
-        return normalized
+        return self._normalize_paged_response(raw, item_keys=["comments"])
 
     async def get_aweme_comment_replies(
         self,

--- a/core/comments_collector.py
+++ b/core/comments_collector.py
@@ -1,18 +1,13 @@
-"""评论采集：针对单个作品拉取全部评论（可选含二级回复），导出为 JSON。
-
-设计要点：
-- 复用 DouyinAPIClient 的分页请求与签名
-- 与下载流程解耦：作为独立的 helper，由 BaseDownloader 在保存媒体后按需调用
-- 输出位置：与媒体同目录，文件名 `{file_stem}_comments.json`
-- 支持上限 max_comments（默认 0 = 不限）和 include_replies
-"""
+"""Bounded, parent-linked Douyin comment collection."""
 
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
+from core.api_client import LoginRequiredError
 from utils.logger import setup_logger
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -20,6 +15,40 @@ if TYPE_CHECKING:  # pragma: no cover
     from storage.metadata_handler import MetadataHandler
 
 logger = setup_logger("CommentsCollector")
+
+_REPLY_FAILURE_CODES = frozenset(
+    {
+        "reply_timeout",
+        "reply_login_required",
+        "reply_verification_required",
+        "reply_api_failed",
+        "reply_response_invalid",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ReplyFailure:
+    aweme_id: str
+    comment_id: str
+    error_code: str
+
+    def __post_init__(self) -> None:
+        if (
+            not self.aweme_id
+            or not self.comment_id
+            or self.error_code not in _REPLY_FAILURE_CODES
+        ):
+            raise ValueError("invalid reply failure")
+
+
+@dataclass(frozen=True)
+class CommentCollectionResult:
+    comments: Tuple[Dict[str, Any], ...]
+    top_level_comment_count: int
+    reply_comment_count: int
+    replies_truncated: bool
+    reply_failures: Tuple[ReplyFailure, ...]
 
 
 class CommentsCollector:
@@ -30,50 +59,166 @@ class CommentsCollector:
         *,
         include_replies: bool = False,
         max_comments: int = 0,
+        max_replies_per_comment: int = 0,
+        max_replies_per_content: int = 0,
         page_size: int = 20,
         retry_delay_seconds: float = 1.0,
     ):
         self.api_client = api_client
         self.metadata_handler = metadata_handler
-        self.include_replies = include_replies
+        self.include_replies = bool(include_replies)
         self.max_comments = int(max_comments or 0)
+        self.max_replies_per_comment = int(max_replies_per_comment or 0)
+        self.max_replies_per_content = int(max_replies_per_content or 0)
+        if self.include_replies and not (
+            1 <= self.max_replies_per_comment <= 20
+            and 1 <= self.max_replies_per_content <= 200
+        ):
+            raise ValueError("reply limits must be within 1..20 and 1..200")
+        if not self.include_replies and (
+            self.max_replies_per_comment or self.max_replies_per_content
+        ):
+            raise ValueError("reply limits require include_replies")
         self.page_size = max(1, int(page_size or 20))
         self.retry_delay_seconds = float(retry_delay_seconds or 1.0)
 
-    async def collect_and_save(self, aweme_id: str, output_path: Path) -> Optional[Dict[str, Any]]:
-        """抓取评论并写入 output_path，失败时返回 None。"""
-        comments = await self.collect(aweme_id)
-        if comments is None:
+    async def collect_and_save(
+        self, aweme_id: str, output_path: Path
+    ) -> Optional[Dict[str, Any]]:
+        result = await self.collect(aweme_id)
+        if result is None:
             return None
 
         payload = {
             "aweme_id": aweme_id,
-            "count": len(comments),
+            "count": len(result.comments),
             "include_replies": self.include_replies,
-            "comments": comments,
+            "top_level_comment_count": result.top_level_comment_count,
+            "reply_comment_count": result.reply_comment_count,
+            "replies_truncated": result.replies_truncated,
+            "reply_failures": [
+                {
+                    "aweme_id": item.aweme_id,
+                    "comment_id": item.comment_id,
+                    "error_code": item.error_code,
+                }
+                for item in result.reply_failures
+            ],
+            "comments": list(result.comments),
         }
-        # MetadataHandler.save_metadata 内部已吞异常并返回 bool
         saved = await self.metadata_handler.save_metadata(payload, output_path)
         if not saved:
             logger.warning("Failed to save comments for %s to %s", aweme_id, output_path)
             return None
         return payload
 
-    async def collect(self, aweme_id: str) -> Optional[List[Dict[str, Any]]]:
-        """抓取评论列表（不写盘），失败返回 None。"""
-        all_comments: List[Dict[str, Any]] = []
+    async def _collect_replies(
+        self,
+        *,
+        aweme_id: str,
+        parent_comment_id: str,
+        budget: int,
+        seen_ids: set[str],
+    ) -> tuple[list[dict[str, Any]], ReplyFailure | None]:
+        rows: list[dict[str, Any]] = []
         cursor = 0
-        seen_ids: set = set()
+        while len(rows) < budget:
+            request_count = min(self.page_size, budget - len(rows))
+            try:
+                page = await self.api_client.get_aweme_comment_replies(
+                    aweme_id=aweme_id,
+                    comment_id=parent_comment_id,
+                    cursor=cursor,
+                    count=request_count,
+                )
+            except LoginRequiredError:
+                return rows, ReplyFailure(
+                    aweme_id, parent_comment_id, "reply_login_required"
+                )
+            except (asyncio.TimeoutError, TimeoutError):
+                return rows, ReplyFailure(aweme_id, parent_comment_id, "reply_timeout")
+            except Exception:  # noqa: BLE001
+                return rows, ReplyFailure(
+                    aweme_id, parent_comment_id, "reply_api_failed"
+                )
 
-        while True:
+            if not isinstance(page, dict):
+                return rows, ReplyFailure(
+                    aweme_id, parent_comment_id, "reply_response_invalid"
+                )
+            risk_flags = page.get("risk_flags")
+            if not isinstance(risk_flags, dict):
+                return rows, ReplyFailure(
+                    aweme_id, parent_comment_id, "reply_response_invalid"
+                )
+            if risk_flags.get("verify_page"):
+                return rows, ReplyFailure(
+                    aweme_id, parent_comment_id, "reply_verification_required"
+                )
+            if risk_flags.get("login_tip"):
+                return rows, ReplyFailure(
+                    aweme_id, parent_comment_id, "reply_login_required"
+                )
+            if page.get("status_code") not in (0, None):
+                return rows, ReplyFailure(
+                    aweme_id, parent_comment_id, "reply_api_failed"
+                )
+            items = page.get("items")
+            if not isinstance(items, list):
+                return rows, ReplyFailure(
+                    aweme_id, parent_comment_id, "reply_response_invalid"
+                )
+
+            for raw in items:
+                if not isinstance(raw, dict):
+                    continue
+                reply_id = str(raw.get("cid") or raw.get("comment_id") or "").strip()
+                if not reply_id or reply_id in seen_ids:
+                    continue
+                seen_ids.add(reply_id)
+                row = dict(raw)
+                row.pop("_replies", None)
+                row["aweme_id"] = aweme_id
+                row["parent_comment_id"] = parent_comment_id
+                rows.append(row)
+                if len(rows) >= budget:
+                    break
+
+            if not page.get("has_more"):
+                return rows, None
+            next_cursor = page.get("max_cursor")
+            if isinstance(next_cursor, bool) or not isinstance(next_cursor, int):
+                return rows, ReplyFailure(
+                    aweme_id, parent_comment_id, "reply_response_invalid"
+                )
+            if next_cursor == cursor:
+                return rows, ReplyFailure(
+                    aweme_id, parent_comment_id, "reply_response_invalid"
+                )
+            cursor = next_cursor
+            await asyncio.sleep(self.retry_delay_seconds * 0.1)
+
+        return rows, None
+
+    async def collect(
+        self, aweme_id: str
+    ) -> Optional[CommentCollectionResult]:
+        rows: List[Dict[str, Any]] = []
+        root_count = 0
+        reply_count = 0
+        cursor = 0
+        seen_ids: set[str] = set()
+        failures: list[ReplyFailure] = []
+
+        while self.max_comments <= 0 or root_count < self.max_comments:
             try:
                 page = await self.api_client.get_aweme_comments(
                     aweme_id,
                     cursor=cursor,
                     count=self.page_size,
-                    include_replies=self.include_replies,
+                    include_replies=False,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "Comments fetch error for %s cursor=%s: %s",
                     aweme_id,
@@ -82,37 +227,74 @@ class CommentsCollector:
                 )
                 return None
 
+            if not isinstance(page, dict):
+                return None
             items = page.get("items") or []
+            if not isinstance(items, list):
+                return None
             if not items:
                 break
 
-            for item in items:
-                if not isinstance(item, dict):
+            for raw in items:
+                if not isinstance(raw, dict):
                     continue
-                cid = item.get("cid") or item.get("comment_id")
-                key = str(cid) if cid else None
-                if key and key in seen_ids:
+                root_id = str(raw.get("cid") or raw.get("comment_id") or "").strip()
+                if root_id and root_id in seen_ids:
                     continue
-                if key:
-                    seen_ids.add(key)
-                all_comments.append(item)
-                if 0 < self.max_comments <= len(all_comments):
-                    return all_comments[: self.max_comments]
+                if root_id:
+                    seen_ids.add(root_id)
+                root = dict(raw)
+                root.pop("_replies", None)
+                root["aweme_id"] = aweme_id
+                root["parent_comment_id"] = ""
+                rows.append(root)
+                root_count += 1
 
-            if not page.get("has_more"):
+                remaining = self.max_replies_per_content - reply_count
+                try:
+                    declared = max(0, int(root.get("reply_comment_total") or 0))
+                except (TypeError, ValueError):
+                    declared = 0
+                if (
+                    self.include_replies
+                    and root_id
+                    and declared > 0
+                    and remaining > 0
+                ):
+                    budget = min(self.max_replies_per_comment, remaining)
+                    replies, failure = await self._collect_replies(
+                        aweme_id=aweme_id,
+                        parent_comment_id=root_id,
+                        budget=budget,
+                        seen_ids=seen_ids,
+                    )
+                    rows.extend(replies)
+                    reply_count += len(replies)
+                    if failure is not None:
+                        failures.append(failure)
+
+                if 0 < self.max_comments <= root_count:
+                    break
+
+            if 0 < self.max_comments <= root_count or not page.get("has_more"):
                 break
             next_cursor = page.get("max_cursor") or 0
+            if isinstance(next_cursor, bool) or not isinstance(next_cursor, int):
+                break
             if next_cursor == cursor:
-                # cursor 未推进但服务器称 has_more=True：可能是接口变更或异常返回，
-                # 升级为 warning 便于线上观察。
                 logger.warning(
-                    "Comments cursor stuck (aweme=%s, cursor=%s, has_more=True); "
-                    "stopping to avoid infinite loop.",
+                    "Comments cursor stuck (aweme=%s, cursor=%s); stopping.",
                     aweme_id,
                     cursor,
                 )
                 break
             cursor = next_cursor
-            await asyncio.sleep(self.retry_delay_seconds * 0.1)  # 轻度节流
+            await asyncio.sleep(self.retry_delay_seconds * 0.1)
 
-        return all_comments
+        return CommentCollectionResult(
+            comments=tuple(rows),
+            top_level_comment_count=root_count,
+            reply_comment_count=reply_count,
+            replies_truncated=bool(failures),
+            reply_failures=tuple(failures),
+        )

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,10 +1,74 @@
 import asyncio
 import sys
 import types
+from unittest.mock import AsyncMock
 
 import pytest
 
 from core.api_client import DouyinAPIClient
+
+
+@pytest.mark.asyncio
+async def test_get_aweme_comment_replies_uses_reply_endpoint_and_cursor(monkeypatch):
+    client = DouyinAPIClient({})
+    captured = {}
+
+    async def fake_default_query():
+        return {"aid": "6383"}
+
+    async def fake_request(path, params):
+        captured["path"] = path
+        captured["params"] = dict(params)
+        return {
+            "status_code": 0,
+            "comments": [{"cid": "reply-1"}],
+            "has_more": 1,
+            "cursor": 20,
+        }
+
+    monkeypatch.setattr(client, "_default_query", fake_default_query)
+    monkeypatch.setattr(client, "_request_json", fake_request)
+
+    page = await client.get_aweme_comment_replies(
+        aweme_id="video-1",
+        comment_id="root-1",
+        cursor=10,
+        count=20,
+    )
+
+    assert captured["path"] == "/aweme/v1/web/comment/list/reply/"
+    assert captured["params"]["item_id"] == "video-1"
+    assert captured["params"]["comment_id"] == "root-1"
+    assert captured["params"]["cursor"] == 10
+    assert captured["params"]["count"] == 20
+    assert page["items"] == [{"cid": "reply-1"}]
+    assert page["has_more"] is True
+    assert page["max_cursor"] == 20
+
+
+@pytest.mark.asyncio
+async def test_get_aweme_comment_replies_preserves_verify_flag(monkeypatch):
+    client = DouyinAPIClient({})
+    monkeypatch.setattr(client, "_default_query", AsyncMock(return_value={}))
+    monkeypatch.setattr(
+        client,
+        "_request_json",
+        AsyncMock(
+            return_value={
+                "status_code": 0,
+                "comments": [],
+                "has_more": 0,
+                "verify_ticket": "present",
+            }
+        ),
+    )
+
+    page = await client.get_aweme_comment_replies(
+        aweme_id="video-1",
+        comment_id="root-1",
+    )
+
+    assert page["risk_flags"]["verify_page"] is True
 
 
 def test_default_query_uses_existing_ms_token():

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -71,6 +71,29 @@ async def test_get_aweme_comment_replies_preserves_verify_flag(monkeypatch):
     assert page["risk_flags"]["verify_page"] is True
 
 
+@pytest.mark.asyncio
+async def test_get_aweme_comment_replies_marks_empty_anti_bot_response_failed(
+    monkeypatch,
+):
+    client = DouyinAPIClient({})
+
+    async def fake_request(*args, **kwargs):
+        del args, kwargs
+        return {}
+
+    monkeypatch.setattr(client, "_request_json", fake_request)
+    page = await client.get_aweme_comment_replies(
+        aweme_id="video-1",
+        comment_id="comment-1",
+        cursor=7,
+        count=20,
+    )
+
+    assert page["items"] == []
+    assert page["max_cursor"] == 7
+    assert page["status_code"] == -1
+
+
 def test_default_query_uses_existing_ms_token():
     client = DouyinAPIClient({"msToken": "token-1"})
     params = asyncio.run(client._default_query())

--- a/tests/test_comments_collector.py
+++ b/tests/test_comments_collector.py
@@ -5,7 +5,12 @@ from typing import Any, Dict, List
 
 import pytest
 
-from core.comments_collector import CommentsCollector
+from core.api_client import LoginRequiredError
+from core.comments_collector import (
+    CommentCollectionResult,
+    CommentsCollector,
+    ReplyFailure,
+)
 from storage.metadata_handler import MetadataHandler
 
 
@@ -118,3 +123,162 @@ async def test_collector_returns_none_on_api_error(tmp_path):
     payload = await collector.collect_and_save("E1", out)
     assert payload is None
     assert not out.exists()
+
+
+class _ReplyAPI:
+    def __init__(self, roots, replies):
+        self.roots = roots
+        self.replies = replies
+        self.reply_calls = []
+
+    async def get_aweme_comments(self, aweme_id, *, cursor, count, include_replies):
+        assert include_replies is False
+        return {
+            "items": self.roots,
+            "has_more": False,
+            "max_cursor": 0,
+            "status_code": 0,
+            "risk_flags": {"login_tip": False, "verify_page": False},
+        }
+
+    async def get_aweme_comment_replies(
+        self, *, aweme_id, comment_id, cursor=0, count=20
+    ):
+        self.reply_calls.append((comment_id, cursor, count))
+        value = self.replies[comment_id].pop(0)
+        if isinstance(value, BaseException):
+            raise value
+        return value
+
+
+def _reply_page(ids, *, has_more=False, cursor=0, verify=False):
+    return {
+        "items": [{"cid": item, "text": item} for item in ids],
+        "has_more": has_more,
+        "max_cursor": cursor,
+        "status_code": 0,
+        "risk_flags": {"login_tip": False, "verify_page": verify},
+    }
+
+
+def _reply_collector(api, *, per_parent=20, per_content=200, root_limit=100):
+    return CommentsCollector(
+        api,
+        MetadataHandler(),
+        include_replies=True,
+        max_comments=root_limit,
+        max_replies_per_comment=per_parent,
+        max_replies_per_content=per_content,
+        retry_delay_seconds=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_collect_flattens_roots_and_replies_in_thread_order():
+    api = _ReplyAPI(
+        [
+            {"cid": "root-1", "reply_comment_total": 2},
+            {"cid": "root-2", "reply_comment_total": 0},
+        ],
+        {"root-1": [_reply_page(["reply-1", "reply-2"])]},
+    )
+
+    result = await _reply_collector(api).collect("video-1")
+
+    assert isinstance(result, CommentCollectionResult)
+    assert [row["cid"] for row in result.comments] == [
+        "root-1",
+        "reply-1",
+        "reply-2",
+        "root-2",
+    ]
+    assert [row["parent_comment_id"] for row in result.comments] == [
+        "",
+        "root-1",
+        "root-1",
+        "",
+    ]
+    assert result.top_level_comment_count == 2
+    assert result.reply_comment_count == 2
+    assert result.replies_truncated is False
+
+
+@pytest.mark.asyncio
+async def test_reply_limit_per_parent_is_normal_bounded_result():
+    api = _ReplyAPI(
+        [{"cid": "root-1", "reply_comment_total": 30}],
+        {
+            "root-1": [
+                _reply_page(
+                    [f"reply-{i}" for i in range(1, 21)],
+                    has_more=True,
+                    cursor=20,
+                ),
+                _reply_page([f"reply-{i}" for i in range(21, 31)]),
+            ]
+        },
+    )
+
+    result = await _reply_collector(api, per_parent=20).collect("video-1")
+
+    assert result.reply_comment_count == 20
+    assert result.replies_truncated is False
+    assert api.reply_calls == [("root-1", 0, 20)]
+
+
+@pytest.mark.asyncio
+async def test_reply_cursor_stuck_marks_incomplete_without_dropping_rows():
+    api = _ReplyAPI(
+        [{"cid": "root-1", "reply_comment_total": 2}],
+        {"root-1": [_reply_page(["reply-1"], has_more=True, cursor=0)]},
+    )
+
+    result = await _reply_collector(api).collect("video-1")
+
+    assert [row["cid"] for row in result.comments] == ["root-1", "reply-1"]
+    assert result.replies_truncated is True
+    assert result.reply_failures == (
+        ReplyFailure("video-1", "root-1", "reply_response_invalid"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_reply_login_failure_preserves_other_threads():
+    api = _ReplyAPI(
+        [
+            {"cid": "root-1", "reply_comment_total": 1},
+            {"cid": "root-2", "reply_comment_total": 1},
+        ],
+        {
+            "root-1": [LoginRequiredError(2483, "login", "/reply/")],
+            "root-2": [_reply_page(["reply-2"])],
+        },
+    )
+
+    result = await _reply_collector(api).collect("video-1")
+
+    assert [row["cid"] for row in result.comments] == [
+        "root-1",
+        "root-2",
+        "reply-2",
+    ]
+    assert result.reply_failures == (
+        ReplyFailure("video-1", "root-1", "reply_login_required"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_collect_and_save_serializes_safe_reply_metadata(tmp_path):
+    api = _ReplyAPI(
+        [{"cid": "root-1", "reply_comment_total": 1}],
+        {"root-1": [RuntimeError("Cookie=sessionid=secret Authorization=Bearer x")]},
+    )
+    collector = _reply_collector(api)
+
+    payload = await collector.collect_and_save("video-1", tmp_path / "comments.json")
+
+    assert payload["replies_truncated"] is True
+    assert payload["reply_failures"][0]["error_code"] == "reply_api_failed"
+    serialized = json.dumps(payload, ensure_ascii=False)
+    assert "sessionid" not in serialized.lower()
+    assert "authorization" not in serialized.lower()


### PR DESCRIPTION
## Summary
- add a bounded reply-list API path for first-level Douyin comments
- flatten replies with parent_comment_id and preserve partial results
- surface empty anti-bot reply responses as an explicit failure instead of a false zero-reply result

## Test plan
- app full suite: 420 passed, 1 skipped
- Ruff and compile checks passed
- real acceptance: first-level collection succeeded; the reply endpoint returned an empty anti-bot response and is now reported as reply_api_failed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds bounded, flattened collection of replies to first-level Douyin comments.
- Adds a dedicated reply endpoint path and treats empty anti-bot responses as failures.
- Adds parent-linked flattened results, reply counts, truncation metadata, and sanitized per-thread failures.
- Adds tests for reply pagination, limits, partial results, and anti-bot responses.

<h3>Confidence Score: 3/5</h3>

This PR is not safe to merge until enabling reply collection can construct the collector through the production downloader configuration path.

The new constructor rejects zero reply limits, while the downloader supplies neither limit when include_replies is enabled, so the feature fails before issuing its first API request.

**Files Needing Attention:** core/comments_collector.py, core/downloader_base.py, config/default_config.py, config.example.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| core/api_client.py | Adds explicit empty-response failure normalization for the dedicated reply endpoint and removes inline reply fetching from the root-comment request. |
| core/comments_collector.py | Implements bounded, parent-linked reply collection and partial-failure metadata, but its required reply limits are not wired into the production construction path. |
| tests/test_api_client.py | Covers reply endpoint parameters, normalized cursors, verification flags, and empty anti-bot responses. |
| tests/test_comments_collector.py | Covers flattening, limits, partial failures, thread isolation, and safe serialization, but constructs reply collectors with limits directly and therefore misses the broken downloader integration. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant D as Downloader
    participant C as CommentsCollector
    participant A as DouyinAPIClient
    D->>C: construct(include_replies, config)
    C->>A: get_aweme_comments(...)
    loop Each root with declared replies
        C->>A: get_aweme_comment_replies(...)
        A-->>C: normalized reply page
    end
    C-->>D: flattened CommentCollectionResult
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: surface empty Douyin reply response..."](https://github.com/jiji262/douyin-downloader/commit/1a59d51eba57b25c11daaffef5d79ef78366b7a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47377666)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->