### PR TITLE
feat: validate and flatten Douyin reply collection

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,4 +1,4 @@
-from .api_client import DouyinAPIClient, LoginRequiredError
+from .api_client import DouyinAPIClient, LoginRequiredError, ReplyAPIError
 from .downloader_factory import DownloaderFactory
 from .mix_downloader import MixDownloader
 from .music_downloader import MusicDownloader
@@ -7,6 +7,7 @@ from .url_parser import URLParser
 __all__ = [
     "DouyinAPIClient",
     "LoginRequiredError",
+    "ReplyAPIError",
     "URLParser",
     "DownloaderFactory",
     "MixDownloader",

--- a/core/api_client.py
+++ b/core/api_client.py
@@ -39,12 +39,48 @@ class LoginRequiredError(Exception):
         )
 
 
+class ReplyAPIError(RuntimeError):
+    """Raised when the reply endpoint cannot produce a trustworthy page."""
+
+    def __init__(self, error_code: str, message: str = ""):
+        self.error_code = str(error_code)
+        self.message = str(message or "")
+        detail = f": {self.message}" if self.message else ""
+        super().__init__(f"{self.error_code}{detail}")
+
+
 def _is_login_required(data: object) -> bool:
     if not isinstance(data, dict):
         return False
     code = data.get("status_code")
     msg = str(data.get("status_msg") or "")
     return code in _LOGIN_REQUIRED_STATUS_CODES or "请先登录" in msg
+
+
+def _reply_login_required(data: object) -> bool:
+    if not isinstance(data, dict):
+        return False
+    code = data.get("status_code")
+    try:
+        code = int(code)
+    except (TypeError, ValueError):
+        pass
+    message = str(data.get("status_msg") or "").lower()
+    return code in _LOGIN_REQUIRED_STATUS_CODES or any(
+        token in message for token in ("login", "请先登录", "璇峰厛鐧诲綍")
+    )
+
+
+def _is_verification_required(data: object) -> bool:
+    if not isinstance(data, dict):
+        return False
+    risk_flags = data.get("risk_flags")
+    if isinstance(risk_flags, dict) and risk_flags.get("verify_page"):
+        return True
+    if data.get("verify_ticket") or data.get("verify_data") or data.get("verify_page"):
+        return True
+    message = str(data.get("status_msg") or "")
+    return any(token in message for token in ("验证码", "验证", "楠岃瘉"))
 
 
 _USER_AGENT_POOL = [
@@ -892,8 +928,39 @@ class DouyinAPIClient:
                 "count": count,
             }
         )
-        raw = await self._request_json("/aweme/v1/web/comment/list/reply/", params)
-        return self._normalize_paged_response(raw, item_keys=["comments"])
+        try:
+            raw = await self._request_json("/aweme/v1/web/comment/list/reply/", params)
+        except LoginRequiredError as exc:
+            raise ReplyAPIError("reply_login_required", str(exc)) from exc
+        except asyncio.TimeoutError as exc:
+            raise ReplyAPIError("reply_timeout", "reply request timed out") from exc
+        except ReplyAPIError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            raise ReplyAPIError("reply_api_failed", "reply request failed") from exc
+
+        if not isinstance(raw, dict) or not raw:
+            raise ReplyAPIError("reply_response_invalid", "empty reply response")
+        if _reply_login_required(raw):
+            raise ReplyAPIError("reply_login_required", "login required")
+        if _is_verification_required(raw):
+            raise ReplyAPIError("reply_verification_required", "verification required")
+
+        status_code = raw.get("status_code")
+        try:
+            status_code_value = int(status_code)
+        except (TypeError, ValueError):
+            raise ReplyAPIError("reply_response_invalid", "invalid status_code") from None
+        if status_code_value != 0:
+            raise ReplyAPIError("reply_api_failed", f"status_code={status_code_value}")
+
+        comments = raw.get("comments")
+        if not isinstance(comments, list):
+            raise ReplyAPIError("reply_response_invalid", "comments field is missing")
+
+        normalized = self._normalize_paged_response(raw, item_keys=["comments"])
+        normalized["response_valid"] = True
+        return normalized
 
     async def resolve_short_url(
         self, short_url: str, *, timeout_seconds: float = 10.0

--- a/core/comments_collector.py
+++ b/core/comments_collector.py
@@ -1,17 +1,10 @@
-"""评论采集：针对单个作品拉取全部评论（可选含二级回复），导出为 JSON。
-
-设计要点：
-- 复用 DouyinAPIClient 的分页请求与签名
-- 与下载流程解耦：作为独立的 helper，由 BaseDownloader 在保存媒体后按需调用
-- 输出位置：与媒体同目录，文件名 `{file_stem}_comments.json`
-- 支持上限 max_comments（默认 0 = 不限）和 include_replies
-"""
+"""Collect top-level Douyin comments and flatten replies into one JSON list."""
 
 from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
 from utils.logger import setup_logger
 
@@ -19,7 +12,50 @@ if TYPE_CHECKING:  # pragma: no cover
     from core.api_client import DouyinAPIClient
     from storage.metadata_handler import MetadataHandler
 
+
 logger = setup_logger("CommentsCollector")
+
+ReplyBrowserFallback = Callable[
+    [str, Optional[str], List[Dict[str, Any]], int, int],
+    Awaitable[Dict[str, Any]],
+]
+
+_SAFE_REPLY_ERROR_CODES = {
+    "reply_api_failed",
+    "reply_response_invalid",
+    "reply_login_required",
+    "reply_verification_required",
+    "reply_timeout",
+    "reply_comment_not_found",
+    "reply_browser_failed",
+}
+
+
+def _comment_id(comment: Dict[str, Any]) -> str:
+    return str(comment.get("cid") or comment.get("comment_id") or "").strip()
+
+
+def _reply_total(comment: Dict[str, Any]) -> int:
+    try:
+        return max(0, int(comment.get("reply_comment_total") or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _normalize_comment(
+    comment: Dict[str, Any], *, parent_comment_id: str = ""
+) -> Dict[str, Any]:
+    normalized = dict(comment)
+    key = _comment_id(normalized)
+    normalized["parent_comment_id"] = parent_comment_id
+    if key:
+        normalized.setdefault("comment_key", key)
+    return normalized
+
+
+def _safe_error_code(value: Any, default: str = "reply_api_failed") -> str:
+    code = str(value or "").strip()
+    return code if code in _SAFE_REPLY_ERROR_CODES else default
 
 
 class CommentsCollector:
@@ -32,16 +68,43 @@ class CommentsCollector:
         max_comments: int = 0,
         page_size: int = 20,
         retry_delay_seconds: float = 1.0,
+        max_replies_per_comment: int = 20,
+        max_replies_per_content: int = 200,
+        reply_browser_fallback: Optional[ReplyBrowserFallback] = None,
+        content_url_resolver: Optional[Callable[[str], Optional[str]]] = None,
     ):
         self.api_client = api_client
         self.metadata_handler = metadata_handler
-        self.include_replies = include_replies
+        self.include_replies = bool(include_replies)
         self.max_comments = int(max_comments or 0)
         self.page_size = max(1, int(page_size or 20))
         self.retry_delay_seconds = float(retry_delay_seconds or 1.0)
+        self.max_replies_per_comment = max(0, int(max_replies_per_comment or 0))
+        self.max_replies_per_content = max(0, int(max_replies_per_content or 0))
+        self.reply_browser_fallback = reply_browser_fallback
+        self.content_url_resolver = content_url_resolver
+        self._content_urls: Dict[str, str] = {}
+        self._last_reply_metrics: Dict[str, Any] = {}
 
-    async def collect_and_save(self, aweme_id: str, output_path: Path) -> Optional[Dict[str, Any]]:
-        """抓取评论并写入 output_path，失败时返回 None。"""
+    def set_content_url(self, aweme_id: str, content_url: str) -> None:
+        """Attach a safe detail-page URL for a later browser fallback."""
+        if aweme_id and content_url:
+            self._content_urls[str(aweme_id)] = str(content_url)
+
+    def _content_url(self, aweme_id: str) -> Optional[str]:
+        if aweme_id in self._content_urls:
+            return self._content_urls[aweme_id]
+        if self.content_url_resolver is None:
+            return None
+        try:
+            value = self.content_url_resolver(aweme_id)
+        except Exception:  # noqa: BLE001
+            return None
+        return str(value) if value else None
+
+    async def collect_and_save(
+        self, aweme_id: str, output_path: Path
+    ) -> Optional[Dict[str, Any]]:
         comments = await self.collect(aweme_id)
         if comments is None:
             return None
@@ -51,8 +114,8 @@ class CommentsCollector:
             "count": len(comments),
             "include_replies": self.include_replies,
             "comments": comments,
+            **self._last_reply_metrics,
         }
-        # MetadataHandler.save_metadata 内部已吞异常并返回 bool
         saved = await self.metadata_handler.save_metadata(payload, output_path)
         if not saved:
             logger.warning("Failed to save comments for %s to %s", aweme_id, output_path)
@@ -60,10 +123,9 @@ class CommentsCollector:
         return payload
 
     async def collect(self, aweme_id: str) -> Optional[List[Dict[str, Any]]]:
-        """抓取评论列表（不写盘），失败返回 None。"""
         all_comments: List[Dict[str, Any]] = []
+        seen_ids: set[str] = set()
         cursor = 0
-        seen_ids: set = set()
 
         while True:
             try:
@@ -71,9 +133,11 @@ class CommentsCollector:
                     aweme_id,
                     cursor=cursor,
                     count=self.page_size,
-                    include_replies=self.include_replies,
+                    # Reply fetching is deliberately orchestrated here so API
+                    # failures can be handed to the browser fallback.
+                    include_replies=False,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "Comments fetch error for %s cursor=%s: %s",
                     aweme_id,
@@ -82,37 +146,260 @@ class CommentsCollector:
                 )
                 return None
 
+            if not isinstance(page, dict):
+                return None
             items = page.get("items") or []
+            if not isinstance(items, list):
+                return None
             if not items:
                 break
 
             for item in items:
                 if not isinstance(item, dict):
                     continue
-                cid = item.get("cid") or item.get("comment_id")
-                key = str(cid) if cid else None
+                normalized = _normalize_comment(item)
+                key = _comment_id(normalized)
                 if key and key in seen_ids:
                     continue
                 if key:
                     seen_ids.add(key)
-                all_comments.append(item)
+                all_comments.append(normalized)
                 if 0 < self.max_comments <= len(all_comments):
-                    return all_comments[: self.max_comments]
+                    all_comments = all_comments[: self.max_comments]
+                    break
 
+            if 0 < self.max_comments <= len(all_comments):
+                break
             if not page.get("has_more"):
                 break
             next_cursor = page.get("max_cursor") or 0
             if next_cursor == cursor:
-                # cursor 未推进但服务器称 has_more=True：可能是接口变更或异常返回，
-                # 升级为 warning 便于线上观察。
                 logger.warning(
-                    "Comments cursor stuck (aweme=%s, cursor=%s, has_more=True); "
-                    "stopping to avoid infinite loop.",
+                    "Comments cursor stuck (aweme=%s, cursor=%s); stopping.",
                     aweme_id,
                     cursor,
                 )
                 break
             cursor = next_cursor
-            await asyncio.sleep(self.retry_delay_seconds * 0.1)  # 轻度节流
+            await asyncio.sleep(self.retry_delay_seconds * 0.1)
 
+        self._last_reply_metrics = self._empty_reply_metrics()
+        if self._replies_enabled():
+            await self._collect_replies(aweme_id, all_comments)
         return all_comments
+
+    def _replies_enabled(self) -> bool:
+        return bool(
+            self.include_replies
+            and self.max_replies_per_comment > 0
+            and self.max_replies_per_content > 0
+        )
+
+    @staticmethod
+    def _empty_reply_metrics() -> Dict[str, Any]:
+        return {
+            "replies_truncated": False,
+            "reply_failures": [],
+            "reply_api_attempted": 0,
+            "reply_api_succeeded": 0,
+            "reply_api_failed": 0,
+            "reply_browser_fallback_attempted": 0,
+            "reply_browser_fallback_succeeded": 0,
+            "reply_browser_fallback_failed": 0,
+            "reply_fallback_failure_counts": {},
+        }
+
+    async def _collect_replies(
+        self, aweme_id: str, comments: List[Dict[str, Any]]
+    ) -> None:
+        failed: List[Dict[str, Any]] = []
+        content_reply_count = 0
+        metrics = self._last_reply_metrics
+
+        for comment in comments:
+            if content_reply_count >= self.max_replies_per_content:
+                if _reply_total(comment) > 0:
+                    metrics["replies_truncated"] = True
+                continue
+            parent_id = _comment_id(comment)
+            if not parent_id or _reply_total(comment) <= 0:
+                continue
+
+            metrics["reply_api_attempted"] += 1
+            remaining = self.max_replies_per_content - content_reply_count
+            replies, error_code, truncated = await self._collect_reply_pages(
+                aweme_id,
+                parent_id,
+                min(self.max_replies_per_comment, remaining),
+            )
+            metrics["replies_truncated"] = metrics["replies_truncated"] or truncated
+            if error_code:
+                metrics["reply_api_failed"] += 1
+                failed.append(
+                    {
+                        "comment": comment,
+                        "comment_id": parent_id,
+                        "error_code": error_code,
+                    }
+                )
+            else:
+                metrics["reply_api_succeeded"] += 1
+            content_reply_count += self._append_replies(
+                comments, replies, parent_id
+            )
+
+        if not failed:
+            return
+
+        if self.reply_browser_fallback is None:
+            self._record_failures(failed, fallback=False)
+            return
+
+        metrics["reply_browser_fallback_attempted"] += len(failed)
+        try:
+            result = await self.reply_browser_fallback(
+                aweme_id,
+                self._content_url(aweme_id),
+                failed,
+                self.max_replies_per_comment,
+                max(0, self.max_replies_per_content - content_reply_count),
+            )
+        except asyncio.TimeoutError:
+            result = {"failures": [{"error_code": "reply_timeout"}]}
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Browser reply fallback failed for %s: %s", aweme_id, exc)
+            result = {"failures": [{"error_code": "reply_browser_failed"}]}
+
+        if not isinstance(result, dict):
+            result = {"failures": [{"error_code": "reply_browser_failed"}]}
+        metrics["replies_truncated"] = metrics["replies_truncated"] or bool(
+            result.get("truncated")
+        )
+        browser_replies = result.get("replies") or result.get("comments") or []
+        if not isinstance(browser_replies, list):
+            browser_replies = []
+        added = 0
+        for reply in browser_replies:
+            if not isinstance(reply, dict) or added >= self.max_replies_per_content:
+                break
+            parent_id = str(reply.get("parent_comment_id") or "").strip()
+            if not parent_id and len(failed) == 1:
+                parent_id = str(failed[0]["comment_id"])
+            normalized = _normalize_comment(reply, parent_comment_id=parent_id)
+            key = _comment_id(normalized)
+            if not key or any(_comment_id(item) == key for item in comments):
+                continue
+            comments.append(normalized)
+            added += 1
+        content_reply_count += added
+        if added:
+            metrics["reply_browser_fallback_succeeded"] += len(
+                {str(item.get("comment_id")) for item in failed if item.get("comment_id")}
+            )
+
+        result_failures = result.get("failures") or []
+        if not isinstance(result_failures, list):
+            result_failures = []
+        if result_failures:
+            metrics["reply_browser_fallback_failed"] += len(failed)
+            self._record_failures(result_failures, fallback=True)
+        elif not added:
+            metrics["reply_browser_fallback_failed"] += len(failed)
+            self._record_failures(
+                [{"error_code": "reply_browser_failed"} for _ in failed],
+                fallback=True,
+            )
+
+    async def _collect_reply_pages(
+        self, aweme_id: str, parent_id: str, limit: int
+    ) -> Tuple[List[Dict[str, Any]], Optional[str], bool]:
+        replies: List[Dict[str, Any]] = []
+        seen_ids: set[str] = set()
+        cursor = 0
+        truncated = False
+        while len(replies) < limit:
+            count = min(self.page_size, limit - len(replies))
+            try:
+                page = await self.api_client.get_aweme_comment_replies(
+                    aweme_id=aweme_id,
+                    comment_id=parent_id,
+                    cursor=cursor,
+                    count=count,
+                )
+            except Exception as exc:  # noqa: BLE001
+                code = _safe_error_code(
+                    getattr(exc, "error_code", None),
+                    "reply_api_failed",
+                )
+                return replies, code, truncated
+
+            if not isinstance(page, dict):
+                return replies, "reply_response_invalid", truncated
+            items = page.get("items")
+            if not isinstance(items, list):
+                return replies, "reply_response_invalid", truncated
+            if not items:
+                if replies:
+                    break
+                return replies, "reply_response_invalid", truncated
+
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                normalized = _normalize_comment(item, parent_comment_id=parent_id)
+                key = _comment_id(normalized)
+                if key and key in seen_ids:
+                    continue
+                if key:
+                    seen_ids.add(key)
+                replies.append(normalized)
+                if len(replies) >= limit:
+                    break
+
+            if len(replies) >= limit:
+                truncated = bool(page.get("has_more"))
+                break
+            if not page.get("has_more"):
+                break
+            next_cursor = page.get("max_cursor") or 0
+            if next_cursor == cursor:
+                truncated = True
+                break
+            cursor = next_cursor
+            await asyncio.sleep(self.retry_delay_seconds * 0.1)
+        return replies, None, truncated
+
+    @staticmethod
+    def _append_replies(
+        comments: List[Dict[str, Any]],
+        replies: List[Dict[str, Any]],
+        parent_id: str,
+    ) -> int:
+        added = 0
+        existing_ids = {_comment_id(item) for item in comments if _comment_id(item)}
+        for reply in replies:
+            key = _comment_id(reply)
+            if key and key in existing_ids:
+                continue
+            normalized = _normalize_comment(reply, parent_comment_id=parent_id)
+            comments.append(normalized)
+            if key:
+                existing_ids.add(key)
+            added += 1
+        return added
+
+    def _record_failures(
+        self, failures: List[Dict[str, Any]], *, fallback: bool
+    ) -> None:
+        metrics = self._last_reply_metrics
+        for failure in failures:
+            if not isinstance(failure, dict):
+                continue
+            code = _safe_error_code(
+                failure.get("error_code"),
+                "reply_browser_failed",
+            )
+            metrics["reply_failures"].append({"error_code": code})
+            if fallback:
+                counts = metrics["reply_fallback_failure_counts"]
+                counts[code] = counts.get(code, 0) + 1

--- a/core/comments_collector.py
+++ b/core/comments_collector.py
@@ -278,24 +278,62 @@ class CommentsCollector:
         browser_replies = result.get("replies") or result.get("comments") or []
         if not isinstance(browser_replies, list):
             browser_replies = []
+        failed_parent_ids = {
+            str(item.get("comment_id") or "").strip()
+            for item in failed
+            if isinstance(item, dict) and item.get("comment_id")
+        }
+        sole_failed_parent = (
+            next(iter(failed_parent_ids)) if len(failed_parent_ids) == 1 else ""
+        )
+        existing_reply_ids = {
+            _comment_id(item)
+            for item in comments
+            if str(item.get("parent_comment_id") or "").strip() and _comment_id(item)
+        }
+        reply_counts_by_parent: Dict[str, int] = {}
+        for item in comments:
+            parent_id = str(item.get("parent_comment_id") or "").strip()
+            if parent_id:
+                reply_counts_by_parent[parent_id] = (
+                    reply_counts_by_parent.get(parent_id, 0) + 1
+                )
+        content_remaining = max(
+            0, self.max_replies_per_content - content_reply_count
+        )
         added = 0
+        succeeded_parents: set[str] = set()
         for reply in browser_replies:
-            if not isinstance(reply, dict) or added >= self.max_replies_per_content:
+            if not isinstance(reply, dict):
+                continue
+            if added >= content_remaining:
+                metrics["replies_truncated"] = True
                 break
             parent_id = str(reply.get("parent_comment_id") or "").strip()
-            if not parent_id and len(failed) == 1:
-                parent_id = str(failed[0]["comment_id"])
-            normalized = _normalize_comment(reply, parent_comment_id=parent_id)
-            key = _comment_id(normalized)
-            if not key or any(_comment_id(item) == key for item in comments):
+            if not parent_id:
+                parent_id = sole_failed_parent
+            if parent_id not in failed_parent_ids:
                 continue
+            key = _comment_id(reply)
+            if not key or key in existing_reply_ids:
+                continue
+            if (
+                reply_counts_by_parent.get(parent_id, 0)
+                >= self.max_replies_per_comment
+            ):
+                metrics["replies_truncated"] = True
+                continue
+            normalized = _normalize_comment(reply, parent_comment_id=parent_id)
             comments.append(normalized)
+            existing_reply_ids.add(key)
+            reply_counts_by_parent[parent_id] = (
+                reply_counts_by_parent.get(parent_id, 0) + 1
+            )
+            succeeded_parents.add(parent_id)
             added += 1
         content_reply_count += added
         if added:
-            metrics["reply_browser_fallback_succeeded"] += len(
-                {str(item.get("comment_id")) for item in failed if item.get("comment_id")}
-            )
+            metrics["reply_browser_fallback_succeeded"] += len(succeeded_parents)
 
         result_failures = result.get("failures") or []
         if not isinstance(result_failures, list):

--- a/storage/metadata_handler.py
+++ b/storage/metadata_handler.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
@@ -12,27 +13,42 @@ from utils.logger import setup_logger
 logger = setup_logger("MetadataHandler")
 
 
+def _reserve_temp_path(save_path: Path) -> Path:
+    descriptor, name = tempfile.mkstemp(
+        dir=str(save_path.parent),
+        prefix=f".{save_path.name}.",
+        suffix=".tmp",
+    )
+    os.close(descriptor)
+    return Path(name)
+
+
 class MetadataHandler:
     def __init__(self):
         self._manifest_lock = asyncio.Lock()
+        self._metadata_replace_lock = asyncio.Lock()
 
     async def save_metadata(self, data: Dict[str, Any], save_path: Path) -> bool:
-        tmp_path = save_path.with_suffix(save_path.suffix + ".tmp")
+        tmp_path = None
         try:
             save_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = await asyncio.to_thread(_reserve_temp_path, save_path)
             async with aiofiles.open(tmp_path, "w", encoding="utf-8") as f:
                 await f.write(json.dumps(data, ensure_ascii=False, indent=2))
                 await f.flush()
-            os.replace(tmp_path, save_path)
+            async with self._metadata_replace_lock:
+                await asyncio.to_thread(os.replace, tmp_path, save_path)
+            tmp_path = None
             return True
         except Exception as e:
             logger.error("Failed to save metadata: %s, error: %s", save_path, e)
             return False
         finally:
-            try:
-                tmp_path.unlink(missing_ok=True)
-            except OSError:
-                pass
+            if tmp_path is not None:
+                try:
+                    await asyncio.to_thread(tmp_path.unlink, missing_ok=True)
+                except OSError:
+                    pass
 
     async def append_download_manifest(self, base_path: Path, record: Dict[str, Any]) -> bool:
         manifest_path = base_path / "download_manifest.jsonl"

--- a/storage/metadata_handler.py
+++ b/storage/metadata_handler.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
@@ -16,13 +17,22 @@ class MetadataHandler:
         self._manifest_lock = asyncio.Lock()
 
     async def save_metadata(self, data: Dict[str, Any], save_path: Path) -> bool:
+        tmp_path = save_path.with_suffix(save_path.suffix + ".tmp")
         try:
-            async with aiofiles.open(save_path, "w", encoding="utf-8") as f:
+            save_path.parent.mkdir(parents=True, exist_ok=True)
+            async with aiofiles.open(tmp_path, "w", encoding="utf-8") as f:
                 await f.write(json.dumps(data, ensure_ascii=False, indent=2))
+                await f.flush()
+            os.replace(tmp_path, save_path)
             return True
         except Exception as e:
             logger.error("Failed to save metadata: %s, error: %s", save_path, e)
             return False
+        finally:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
 
     async def append_download_manifest(self, base_path: Path, record: Dict[str, Any]) -> bool:
         manifest_path = base_path / "download_manifest.jsonl"

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -4,7 +4,7 @@ import types
 
 import pytest
 
-from core.api_client import DouyinAPIClient
+from core.api_client import DouyinAPIClient, ReplyAPIError
 
 
 def test_default_query_uses_existing_ms_token():
@@ -521,3 +521,75 @@ async def test_get_video_detail_returns_on_first_success():
     assert detail is not None
     assert detail["aweme_id"] == "456"
     assert call_count == 1  # no retry needed
+
+
+@pytest.mark.asyncio
+async def test_reply_endpoint_accepts_valid_comments_page(monkeypatch):
+    client = DouyinAPIClient({"msToken": "token-1"})
+
+    async def _fake_request_json(path, _params, **_kwargs):
+        assert path == "/aweme/v1/web/comment/list/reply/"
+        return {
+            "status_code": 0,
+            "comments": [{"cid": "reply-1", "text": "reply"}],
+            "has_more": 0,
+            "cursor": 0,
+        }
+
+    monkeypatch.setattr(client, "_request_json", _fake_request_json)
+    page = await client.get_aweme_comment_replies(
+        aweme_id="aweme-1", comment_id="comment-1"
+    )
+
+    assert page["items"] == [{"cid": "reply-1", "text": "reply"}]
+    assert page["response_valid"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("raw", "error_code"),
+    [
+        ({}, "reply_response_invalid"),
+        ({"status_code": 0}, "reply_response_invalid"),
+        ({"status_code": 500, "comments": []}, "reply_api_failed"),
+        (
+            {"status_code": 2483, "status_msg": "login required", "comments": []},
+            "reply_login_required",
+        ),
+        (
+            {"status_code": 0, "verify_ticket": "ticket", "comments": []},
+            "reply_verification_required",
+        ),
+    ],
+)
+async def test_reply_endpoint_rejects_invalid_or_risky_pages(
+    monkeypatch, raw, error_code
+):
+    client = DouyinAPIClient({"msToken": "token-1"})
+
+    async def _fake_request_json(_path, _params, **_kwargs):
+        return raw
+
+    monkeypatch.setattr(client, "_request_json", _fake_request_json)
+
+    with pytest.raises(ReplyAPIError) as exc_info:
+        await client.get_aweme_comment_replies(
+            aweme_id="aweme-1", comment_id="comment-1"
+        )
+    assert exc_info.value.error_code == error_code
+
+
+@pytest.mark.asyncio
+async def test_reply_endpoint_maps_timeout(monkeypatch):
+    client = DouyinAPIClient({"msToken": "token-1"})
+
+    async def _fake_request_json(_path, _params, **_kwargs):
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(client, "_request_json", _fake_request_json)
+
+    with pytest.raises(ReplyAPIError) as exc_info:
+        await client.get_aweme_comment_replies(
+            aweme_id="aweme-1", comment_id="comment-1"
+        )
+    assert exc_info.value.error_code == "reply_timeout"

--- a/tests/test_comments_collector.py
+++ b/tests/test_comments_collector.py
@@ -277,3 +277,129 @@ async def test_collector_deduplicates_reply_ids_and_honors_limits(tmp_path):
     assert payload is not None
     assert [item["cid"] for item in payload["comments"]] == ["root-1", "reply-1", "reply-2"]
     assert payload["replies_truncated"] is True
+
+
+@pytest.mark.asyncio
+async def test_browser_fallback_enforces_parent_limit_dedup_and_parent_allowlist(
+    tmp_path,
+):
+    class _ReplyFailure(RuntimeError):
+        error_code = "reply_response_invalid"
+
+    api = _ReplyAPIClient(reply_error=_ReplyFailure("empty"))
+
+    async def _fallback(*_args):
+        replies = [
+            {
+                "cid": f"reply-{index}",
+                "parent_comment_id": "root-1",
+            }
+            for index in range(25)
+        ]
+        replies.extend(
+            [
+                {"cid": "reply-0", "parent_comment_id": "root-1"},
+                {"cid": "outside-1", "parent_comment_id": "not-failed"},
+            ]
+        )
+        return {"replies": replies}
+
+    collector = CommentsCollector(
+        api,
+        MetadataHandler(),
+        include_replies=True,
+        max_replies_per_comment=20,
+        max_replies_per_content=200,
+        reply_browser_fallback=_fallback,
+    )
+
+    payload = await collector.collect_and_save("A1", tmp_path / "out.json")
+
+    assert payload is not None
+    replies = [
+        item for item in payload["comments"] if item["parent_comment_id"]
+    ]
+    assert len(replies) == 20
+    assert {item["parent_comment_id"] for item in replies} == {"root-1"}
+    assert len({item["cid"] for item in replies}) == 20
+    assert payload["replies_truncated"] is True
+
+
+@pytest.mark.asyncio
+async def test_browser_fallback_honors_content_limit_after_api_replies(tmp_path):
+    class _MixedReplyAPI:
+        async def get_aweme_comments(
+            self, aweme_id, *, cursor, count, include_replies
+        ):
+            return {
+                "items": [
+                    {
+                        "cid": "api-root",
+                        "reply_comment_total": 10,
+                    },
+                    *[
+                        {
+                            "cid": f"failed-root-{index}",
+                            "reply_comment_total": 20,
+                        }
+                        for index in range(11)
+                    ],
+                ],
+                "has_more": False,
+                "max_cursor": 0,
+            }
+
+        async def get_aweme_comment_replies(
+            self, *, aweme_id, comment_id, cursor, count
+        ):
+            if comment_id == "api-root":
+                return {
+                    "items": [
+                        {
+                            "cid": f"api-reply-{index}",
+                            "parent_comment_id": "api-root",
+                        }
+                        for index in range(10)
+                    ],
+                    "has_more": False,
+                    "max_cursor": 0,
+                }
+            error = RuntimeError("empty")
+            error.error_code = "reply_response_invalid"
+            raise error
+
+    async def _fallback(*_args):
+        return {
+            "replies": [
+                {
+                    "cid": f"browser-reply-{parent}-{index}",
+                    "parent_comment_id": f"failed-root-{parent}",
+                }
+                for parent in range(11)
+                for index in range(20)
+            ]
+        }
+
+    collector = CommentsCollector(
+        _MixedReplyAPI(),
+        MetadataHandler(),
+        include_replies=True,
+        max_replies_per_comment=20,
+        max_replies_per_content=200,
+        reply_browser_fallback=_fallback,
+    )
+
+    payload = await collector.collect_and_save("A1", tmp_path / "out.json")
+
+    assert payload is not None
+    replies = [
+        item for item in payload["comments"] if item["parent_comment_id"]
+    ]
+    assert len(replies) == 200
+    parent_counts = {}
+    for reply in replies:
+        parent_id = reply["parent_comment_id"]
+        parent_counts[parent_id] = parent_counts.get(parent_id, 0) + 1
+    assert all(count <= 20 for count in parent_counts.values())
+    assert len({item["cid"] for item in replies}) == 200
+    assert payload["replies_truncated"] is True

--- a/tests/test_comments_collector.py
+++ b/tests/test_comments_collector.py
@@ -21,6 +21,33 @@ class _FakeAPIClient:
         return self._pages.pop(0)
 
 
+class _ReplyAPIClient:
+    def __init__(self, reply_page=None, reply_error=None):
+        self.reply_page = reply_page
+        self.reply_error = reply_error
+        self.reply_calls = []
+
+    async def get_aweme_comments(self, aweme_id, *, cursor, count, include_replies):
+        assert include_replies is False
+        return {
+            "items": [
+                {
+                    "cid": "root-1",
+                    "text": "root",
+                    "reply_comment_total": 1,
+                }
+            ],
+            "has_more": False,
+            "max_cursor": 0,
+        }
+
+    async def get_aweme_comment_replies(self, *, aweme_id, comment_id, cursor, count):
+        self.reply_calls.append((aweme_id, comment_id, cursor, count))
+        if self.reply_error is not None:
+            raise self.reply_error
+        return self.reply_page
+
+
 @pytest.mark.asyncio
 async def test_collector_paginates_until_no_more(tmp_path):
     api = _FakeAPIClient(
@@ -118,3 +145,135 @@ async def test_collector_returns_none_on_api_error(tmp_path):
     payload = await collector.collect_and_save("E1", out)
     assert payload is None
     assert not out.exists()
+
+
+@pytest.mark.asyncio
+async def test_collector_flattens_api_replies_with_parent_id(tmp_path):
+    api = _ReplyAPIClient(
+        reply_page={
+            "items": [{"cid": "reply-1", "text": "reply"}],
+            "has_more": False,
+            "max_cursor": 0,
+        }
+    )
+    collector = CommentsCollector(
+        api,
+        MetadataHandler(),
+        include_replies=True,
+        max_replies_per_comment=20,
+        max_replies_per_content=200,
+    )
+
+    payload = await collector.collect_and_save("A1", tmp_path / "out.json")
+
+    assert payload is not None
+    assert [item["cid"] for item in payload["comments"]] == ["root-1", "reply-1"]
+    assert payload["comments"][0]["parent_comment_id"] == ""
+    assert payload["comments"][1]["parent_comment_id"] == "root-1"
+    assert payload["reply_api_attempted"] == 1
+    assert payload["reply_browser_fallback_attempted"] == 0
+
+
+@pytest.mark.asyncio
+async def test_collector_uses_browser_fallback_after_reply_api_failure(tmp_path):
+    class _ReplyFailure(RuntimeError):
+        error_code = "reply_response_invalid"
+
+    api = _ReplyAPIClient(reply_error=_ReplyFailure("empty"))
+    fallback_calls = []
+
+    async def _fallback(aweme_id, content_url, failed, per_comment, remaining):
+        fallback_calls.append((aweme_id, content_url, failed, per_comment, remaining))
+        return {
+            "replies": [
+                {
+                    "cid": "reply-1",
+                    "text": "browser reply",
+                    "parent_comment_id": "root-1",
+                }
+            ]
+        }
+
+    collector = CommentsCollector(
+        api,
+        MetadataHandler(),
+        include_replies=True,
+        max_replies_per_comment=20,
+        max_replies_per_content=200,
+        reply_browser_fallback=_fallback,
+    )
+    collector.set_content_url("A1", "https://www.douyin.com/video/123")
+
+    payload = await collector.collect_and_save("A1", tmp_path / "out.json")
+
+    assert payload is not None
+    assert [item["cid"] for item in payload["comments"]] == ["root-1", "reply-1"]
+    assert fallback_calls[0][0:2] == ("A1", "https://www.douyin.com/video/123")
+    assert fallback_calls[0][2][0]["error_code"] == "reply_response_invalid"
+    assert payload["reply_browser_fallback_attempted"] == 1
+    assert payload["reply_browser_fallback_succeeded"] == 1
+
+
+@pytest.mark.asyncio
+async def test_collector_keeps_top_level_when_reply_fallback_fails(tmp_path):
+    class _ReplyFailure(RuntimeError):
+        error_code = "reply_login_required"
+
+    api = _ReplyAPIClient(reply_error=_ReplyFailure("login"))
+
+    async def _fallback(*_args):
+        return {"failures": [{"error_code": "reply_login_required"}]}
+
+    collector = CommentsCollector(
+        api,
+        MetadataHandler(),
+        include_replies=True,
+        max_replies_per_comment=20,
+        max_replies_per_content=200,
+        reply_browser_fallback=_fallback,
+    )
+
+    payload = await collector.collect_and_save("A1", tmp_path / "out.json")
+
+    assert payload is not None
+    assert [item["cid"] for item in payload["comments"]] == ["root-1"]
+    assert payload["reply_failures"] == [{"error_code": "reply_login_required"}]
+    assert payload["reply_browser_fallback_failed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_collector_deduplicates_reply_ids_and_honors_limits(tmp_path):
+    class _PagedReplyAPI(_ReplyAPIClient):
+        def __init__(self):
+            super().__init__()
+            self.pages = [
+                {
+                    "items": [{"cid": "reply-1"}, {"cid": "reply-2"}],
+                    "has_more": True,
+                    "max_cursor": 2,
+                },
+                {
+                    "items": [{"cid": "reply-2"}, {"cid": "reply-3"}],
+                    "has_more": False,
+                    "max_cursor": 3,
+                },
+            ]
+
+        async def get_aweme_comment_replies(self, **kwargs):
+            self.reply_calls.append(kwargs)
+            return self.pages.pop(0)
+
+    api = _PagedReplyAPI()
+    collector = CommentsCollector(
+        api,
+        MetadataHandler(),
+        include_replies=True,
+        max_replies_per_comment=2,
+        max_replies_per_content=2,
+    )
+
+    payload = await collector.collect_and_save("A1", tmp_path / "out.json")
+
+    assert payload is not None
+    assert [item["cid"] for item in payload["comments"]] == ["root-1", "reply-1", "reply-2"]
+    assert payload["replies_truncated"] is True

--- a/tests/test_metadata_handler.py
+++ b/tests/test_metadata_handler.py
@@ -1,0 +1,73 @@
+import asyncio
+import json
+
+import pytest
+
+import storage.metadata_handler as metadata_module
+from storage.metadata_handler import MetadataHandler
+
+
+@pytest.mark.asyncio
+async def test_save_metadata_concurrently_uses_independent_temp_files(
+    tmp_path, monkeypatch
+):
+    real_open = metadata_module.aiofiles.open
+    both_flushed = asyncio.Event()
+    flush_count = 0
+    flush_lock = asyncio.Lock()
+
+    class _GatedFile:
+        def __init__(self, context):
+            self._context = context
+            self._file = None
+
+        async def __aenter__(self):
+            self._file = await self._context.__aenter__()
+            return self
+
+        async def __aexit__(self, *args):
+            return await self._context.__aexit__(*args)
+
+        async def write(self, content):
+            return await self._file.write(content)
+
+        async def flush(self):
+            nonlocal flush_count
+            await self._file.flush()
+            async with flush_lock:
+                flush_count += 1
+                if flush_count == 2:
+                    both_flushed.set()
+            await both_flushed.wait()
+
+    def _gated_open(*args, **kwargs):
+        return _GatedFile(real_open(*args, **kwargs))
+
+    monkeypatch.setattr(metadata_module.aiofiles, "open", _gated_open)
+    handler = MetadataHandler()
+    target = tmp_path / "shared.json"
+    payloads = [{"writer": "first"}, {"writer": "second"}]
+
+    results = await asyncio.gather(
+        *(handler.save_metadata(payload, target) for payload in payloads)
+    )
+
+    assert results == [True, True]
+    assert json.loads(target.read_text(encoding="utf-8")) in payloads
+    assert list(tmp_path.iterdir()) == [target]
+
+
+@pytest.mark.asyncio
+async def test_save_metadata_removes_unique_temp_file_after_replace_failure(
+    tmp_path, monkeypatch
+):
+    def _fail_replace(*_args):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(metadata_module.os, "replace", _fail_replace)
+    target = tmp_path / "metadata.json"
+
+    saved = await MetadataHandler().save_metadata({"value": 1}, target)
+
+    assert saved is False
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## Summary
- add safe ReplyAPIError classification for empty, invalid, login, verification, and timeout responses
- flatten reply API results into comments with parent_comment_id, limits, deduplication, and fallback callback contract
- make metadata JSON writes atomic

## Verification
- app pytest: 423 passed, 1 skipped
- Ruff and compileall passed

The companion root POC PR is https://github.com/liuhan-agent/douyin-comment-poc/pull/4.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR validates reply endpoint responses and adds bounded, flattened reply collection with fallback metrics, while changing metadata persistence to temporary-file replacement.
- Exports and classifies reply-specific API failures.
- Collects and deduplicates replies into the top-level comment list with parent identifiers and fallback reporting.
- Writes metadata through a temporary file before atomically replacing the destination.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until concurrent metadata saves use isolated temporary files; fallback limit enforcement is also worth tightening.

Concurrent saves to the same destination share one temporary pathname across asynchronous writes and replacement, allowing failed or incorrect persistence, while fallback replies can exceed the collector’s declared limits.

**Files Needing Attention:** storage/metadata_handler.py, core/comments_collector.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| core/api_client.py | Adds explicit validation and safe error classification for reply endpoint responses. |
| core/comments_collector.py | Adds flattened reply orchestration and fallback metrics, but fallback results can bypass configured limits. |
| storage/metadata_handler.py | Adds atomic replacement, but the shared deterministic temporary path is unsafe for concurrent saves to one destination. |
| tests/test_api_client.py | Covers valid reply pages and invalid, login, verification, and timeout classifications. |
| tests/test_comments_collector.py | Covers flattening, fallback, deduplication, and API-path limits but not concurrent writes or fallback over-limit results. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Fetch top-level comments] --> B{Replies enabled?}
    B -- No --> G[Save flattened payload]
    B -- Yes --> C[Fetch reply pages]
    C --> D{Reply API succeeded?}
    D -- Yes --> E[Normalize, deduplicate, and append]
    D -- No --> F[Invoke browser fallback]
    F --> E
    E --> G
    G --> H[Write temporary JSON]
    H --> I[Replace destination]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add reply api validation and brows..."](https://github.com/jiji262/douyin-downloader/commit/da8a8183f2bb8506f76ffedaff72a97873167f07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47388448)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->