### PR TITLE
HAI-11: factory day-key + transcript fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,11 @@ A Python-based Douyin (TikTok China) batch downloader that fetches videos, galle
   - `utils/proxy.py` — desktop-only policy for following the OS proxy when the app proxy setting is blank; CLI keeps explicit-only proxy semantics.
   - `storage/database.py` — desktop adds TikTok, Following, and My Content schema/helpers; only dependency-neutral database tests remain byte-identical.
   - `tests/test_database_platform.py`, `tests/test_database_desktop_schema.py`, `tests/test_retry_executor.py` — desktop-only tests and not present here.
+  - `local_pipeline/` — CLI production MCP transcript + `_factory` index; not part of Douzy desktop sync.
+  - `core/downloader_base.py` — CLI adds `_after_video_assets_downloaded` MCP hook + factory append; desktop sync must not wipe without porting.
+  - `core/user_downloader.py` — CLI default `collect_use_aweme_author_dir: true` lands collect under each aweme's original author (not `self/…`); daily automation also forces `group_by_mode: false` so paths are `<author>/{date}_{title}_{id}/` with no `collect` layer. Set the flag false to restore feed-owner dirs.
+  - `config/default_config.py` — CLI adds `mcp_transcript` defaults + `collect_use_aweme_author_dir`; keep Douzy built-in `transcript.enabled: false` for production.
+  - `config.automation.yml`, `scripts/daily-favorites.ps1`, `tools/run_mcp_transcript.py`, `tools/merge_daily_config.py` — CLI-only daily ingest path (`group_by_mode: false`, MCP transcript on).
 
 ### Testing Requirements
 - Run: `python -m pytest tests/`

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -1,0 +1,96 @@
+# 本地部署说明（本机）
+
+路径：`D:\dev\github\douyin-downloader`（业务工具仓，不进 `D:\dev\infra`）
+
+## 已完成
+
+- 克隆仓库
+- `.venv` + 依赖（含 Playwright Chromium、FastAPI/Uvicorn）
+- `config.yml`（已 gitignore，勿提交）
+- 热搜榜冒烟：`--hot-board` 已通
+
+## 生产面（收藏日更 → MCP 转写 → `_factory`）
+
+权威路径与权限见 ghaishu：`.agents/contracts/media-sources.md`。
+
+| 用途 | 落点 |
+|------|------|
+| 日更入口 | `scripts/daily-favorites.ps1` |
+| 计划任务说明 | `scripts/SCHEDULED-TASK.md` |
+| 薄配置 overlay | `config.automation.yml`（与 `%APPDATA%\Douzy\config.yml` 合并） |
+| 转写 hook | `local_pipeline/mcp_transcript.py`（直调 MCP `extract_text`，非 `:8080`） |
+| 存量单条补跑 | `tools/run_mcp_transcript.py` |
+| 配置合并 | `tools/merge_daily_config.py` |
+
+硬约束：
+
+- Douzy `transcript.enabled` 保持 `false`；生产转写走 `mcp_transcript`
+- Cookie / 媒体根复用 `%APPDATA%\Douzy\`（`.cookies.json` + `path: G:\media\douyin`）
+- 收藏落盘：`collect_use_aweme_author_dir: true` + `group_by_mode: false` → `G:\media\douyin\<原作者>\{date}_{title}_{id}\`（无 `self`/`collect` 层）
+- 文件名模板保持 Douzy 默认 `{date}_{title}_{id}`（引擎已截断，不必再缩短）
+- API Key：优先环境变量 `DOUYIN_API_KEY`（否则 `API_KEY` / `OPENAI_API_KEY`）；禁止写入 git
+
+### 存量补洞（本地已有 mp4、日更会 skip 下载时）
+
+日更对已落盘 aweme **不会**再进 hook。补转写须显式指定路径（禁止整库递归脚本当 Agent 默认动作）：
+
+**单条：**
+
+```powershell
+$env:DOUYIN_API_KEY = "..."   # 或依赖 Douzy transcript.api_key 由日更脚本进程内加载
+.\.venv\Scripts\python.exe tools\run_mcp_transcript.py `
+  --aweme-id <id> `
+  --video "G:\media\douyin\作者\...\xxx_<id>.mp4" `
+  --author "作者名"
+```
+
+**按失败 delta 批量（只读 JSONL，不扫库）：**
+
+```powershell
+.\.venv\Scripts\python.exe tools\backfill_failed_from_delta.py `
+  --delta G:\media\douyin\_factory\delta-2026-08-09.jsonl
+```
+
+然后投影到 ghaishu（缺 delta 默认非 0；历史 UTC 错位可用 `-CompatMiskeyedUtc`）：
+
+```powershell
+powershell -File D:\ghaishu\.scripts\ingest-douyin-delta.ps1
+# 或恢复错位批次：
+powershell -File D:\ghaishu\.scripts\ingest-douyin-delta.ps1 -Date 2026-08-10 -CompatMiskeyedUtc
+```
+
+转写默认优先本地 mp4 ASR（规避分享页 HTML / `videoInfoRes` 间歇失败）。
+
+长片偶发硅基 `500`（出现 `.transcript.err.txt`）：下载仍算成功；稍后重跑上面的补洞命令即可。
+
+## 还差一步：Cookie（调试 / 非 Douzy 路径）
+
+若不用 Douzy 目录、改用仓库 `config.yml`：
+
+```bat
+scripts\fetch-cookies.bat
+```
+
+生产日更只维护 `%APPDATA%\Douzy\.cookies.json`。
+
+## 常用命令
+
+```powershell
+# 生产日更（收藏增量 + MCP 转写 + _factory）
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\daily-favorites.ps1 -CollectLimit 5
+
+# 单链下载（调试）
+.\.venv\Scripts\python.exe run.py -c "$env:APPDATA\Douzy\config.yml" -u "https://..." -v
+
+# REST API（本机，默认 8010；8000 常被占用）
+.\scripts\serve.ps1
+
+# 热搜（可不登录）
+.\.venv\Scripts\python.exe run.py --hot-board 10 -p .\Downloaded
+```
+
+## 输出
+
+- 生产媒体根：`G:\media\douyin`（与 Douzy 一致）
+- 工厂索引：`G:\media\douyin\_factory\`（`manifest.jsonl`、`delta-YYYY-MM-DD.jsonl`）
+- 去重库：尽量共用 `%APPDATA%\Douzy\dy_downloader.db`（日更写入绝对 `database_path`）

--- a/config.automation.yml
+++ b/config.automation.yml
@@ -1,0 +1,74 @@
+# Thin automation overlay for favorites daily ingest (M1/M2).
+#
+# Usage (prefer Douzy config as base so path/cookies/music align):
+#   1) daily-favorites.ps1 merges %APPDATA%\Douzy\config.yml + this file
+#   2) or: run with --config pointing at a generated temp yml
+#
+# Hard requirements:
+#   - transcript.enabled: false  (Douzy built-in TranscriptManager OFF)
+#   - mcp_transcript.enabled: true  (MCP extract_text library/CLI direct call)
+#   - music: true  (audio authority in G:\media\douyin)
+#   - path: same as Douzy → G:\media\douyin
+#   - cookie: auto  (loads %APPDATA%\Douzy\.cookies.json next to Douzy config)
+#   - database_path: absolute Douzy DB when sharing; else filesystem+_factory dedupe
+#   - collect_use_aweme_author_dir: true → <原作者>/...（对齐 Douzy；勿用 self/collect）
+#   - group_by_mode: false → 日更不分 collect/post 层，统一 <原作者>/{date}_{title}_{id}/
+#
+# API key: set DOUYIN_API_KEY (preferred). Fallbacks: API_KEY, OPENAI_API_KEY.
+# Never commit keys. daily-favorites may load Douzy transcript.api_key into
+# process env only when those env vars are empty.
+
+link:
+  - https://www.douyin.com/user/self
+
+path: G:\media\douyin
+
+cookie: auto
+auto_cookie: true
+
+video: true
+music: true
+cover: true
+avatar: false
+json: false
+
+mode:
+  - collect
+
+# 收藏落盘用作品原作者目录（默认 true；与 Douzy author_dir=nickname 对齐）
+collect_use_aweme_author_dir: true
+# 日更不分模式层，统一作者根下直落（无 collect/）
+group_by_mode: false
+
+number:
+  collect: 20
+  collectmix: 0
+  post: 0
+  like: 0
+  mix: 0
+  music: 0
+
+increase:
+  collect: true
+  collectmix: false
+  post: false
+  like: false
+  mix: false
+  music: false
+
+database: true
+# Prefer sharing Douzy DB (D2). Relative paths resolve to CWD — use absolute:
+# database_path: C:\Users\<you>\AppData\Roaming\Douzy\dy_downloader.db
+# daily-favorites.ps1 rewrites this to the live Douzy userData path.
+
+transcript:
+  enabled: false
+
+mcp_transcript:
+  enabled: true
+  api_key_env: DOUYIN_API_KEY
+  mcp_scripts_path: D:\dev\github\douyin-mcp-server\douyin-video\scripts
+  mcp_python: D:\dev\github\douyin-mcp-server\.venv\Scripts\python.exe
+  timeout_seconds: 600
+  # Prefer local mp4 ASR; share-URL HTML / videoInfoRes is fallback only (HAI-11).
+  prefer_local_video: true

--- a/config.example.yml
+++ b/config.example.yml
@@ -30,6 +30,15 @@ folder_template: "{date}_{title}_{id}"
 # 切换只影响后续下载，不会迁移已存在的目录。
 author_dir: "nickname"
 
+# 是否按下载模式再分一层（post / like / collect …）。默认 true。
+# 日更生产面（favorites → G:\media\douyin）强制 false：
+#   → <原作者>/{date}_{title}_{id}/（无 collect 层）。见 config.automation.yml / LOCAL_SETUP.md
+# group_by_mode: true
+
+# collect / collectmix：顶层用作品原作者目录（默认 true，对齐 Douzy）。
+# false 则落在收藏夹主人占位名 self/collect/…。日更保持 true。
+# collect_use_aweme_author_dir: true
+
 # 默认不下载作者主页置顶作品；如需包含置顶，改为 true
 download_pinned: false
 
@@ -74,6 +83,7 @@ video_quality: highest
 progress:
   quiet_logs: true
 
+# Douzy / 桌面内置转写。生产日更保持 enabled: false；转写走下方 mcp_transcript。
 transcript:
   enabled: false
   model: gpt-4o-mini-transcribe
@@ -84,6 +94,17 @@ transcript:
   api_url: https://api.openai.com/v1/audio/transcriptions
   api_key_env: OPENAI_API_KEY
   api_key: ""
+
+# 生产转写（CLI）：下载后直调 MCP extract_text（库/CLI，非 :8080），写旁侧 .transcript.txt
+# 并追加 G:\media\douyin\_factory。日更由 config.automation.yml 打开；密钥用 DOUYIN_API_KEY。
+# 说明见 LOCAL_SETUP.md；存量补跑：tools/run_mcp_transcript.py
+# mcp_transcript:
+#   enabled: false
+#   api_key_env: DOUYIN_API_KEY
+#   mcp_scripts_path: D:\dev\github\douyin-mcp-server\douyin-video\scripts
+#   mcp_python: D:\dev\github\douyin-mcp-server\.venv\Scripts\python.exe
+#   timeout_seconds: 600
+#   prefer_local_video: true  # local mp4 ASR first; share URL is fallback only
 
 browser_fallback:
   enabled: true

--- a/config/default_config.py
+++ b/config/default_config.py
@@ -27,6 +27,9 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     #   True  - 作者目录下再分 post/like/... （默认，与历史行为一致）
     #   False - 不分模式层，文件直接落在作者目录下（复刻 legacy 布局，无 POST 文件夹）
     "group_by_mode": True,
+    # collect / collectmix：顶层目录用作品原作者（与 Douzy 作者目录一致），
+    # 而不是收藏夹主人占位名 "self"。关闭则恢复 feed-owner 目录（self/collect）。
+    "collect_use_aweme_author_dir": True,
     "download_pinned": False,
     # 下载博主作品时，是否在作者根目录覆盖保存一张主页首屏截图。
     "homepage_screenshot": False,
@@ -80,6 +83,17 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         # deliberately does not surface this toggle — see
         # ``.kiro/specs/transcript-audio-extract-and-ui`` Requirement 1.
         "upload_audio_only": True,
+    },
+    # Production transcript: MCP extract_text direct call (not :8080, not Douzy built-in).
+    # Enable via automation overlay / daily-favorites. Keep transcript.enabled false.
+    "mcp_transcript": {
+        "enabled": False,
+        "api_key_env": "DOUYIN_API_KEY",
+        "mcp_scripts_path": r"D:\dev\github\douyin-mcp-server\douyin-video\scripts",
+        "mcp_python": r"D:\dev\github\douyin-mcp-server\.venv\Scripts\python.exe",
+        "timeout_seconds": 600,
+        # Prefer local mp4 ASR over share-URL HTML parse (avoids videoInfoRes failures).
+        "prefer_local_video": True,
     },
     "auto_cookie": False,
     "browser_fallback": {

--- a/core/downloader_base.py
+++ b/core/downloader_base.py
@@ -15,6 +15,14 @@ from control import QueueManager, RateLimiter, RetryHandler
 from core.api_client import DouyinAPIClient
 from core.metadata import extract_author_sec_uid, extract_video_cover_urls
 from core.transcript_manager import TranscriptManager
+from local_pipeline.mcp_transcript import (
+    append_factory_records,
+    build_factory_record,
+    mcp_transcript_enabled,
+    process_aweme_transcript_async,
+    title_from_stem,
+    transcript_txt_path,
+)
 from storage import Database, FileManager, MetadataHandler
 from storage.database import order_cover_mirrors
 from utils.logger import setup_logger
@@ -748,10 +756,77 @@ class BaseDownloader(ABC):
         )
 
         if media_type == "video" and video_path is not None:
+            await self._after_video_assets_downloaded(
+                aweme_id=aweme_id,
+                author_name=author.get("nickname", author_name),
+                title=desc,
+                save_dir=save_dir,
+                file_stem=file_stem,
+                video_path=video_path,
+            )
+
+        if primary_media_downloaded:
+            self._mark_local_aweme_downloaded(aweme_id)
+        logger.info("Downloaded selected assets for %s: %s (%s)", media_type, desc, aweme_id)
+        return True
+
+    async def _after_video_assets_downloaded(
+        self,
+        *,
+        aweme_id: str,
+        author_name: str,
+        title: str,
+        save_dir: Path,
+        file_stem: str,
+        video_path: Path,
+    ) -> None:
+        """MCP extract hook (production) or built-in TranscriptManager (off by default).
+
+        Failures never fail the download. Always append a ``_factory`` index row
+        when the media root looks like a production library (has or can create
+        ``_factory``).
+        """
+        mcp_cfg = self.config.get("mcp_transcript") or {}
+        if not isinstance(mcp_cfg, dict):
+            mcp_cfg = {}
+
+        transcript_status = "skipped"
+        transcript_path: Optional[str] = None
+
+        if mcp_transcript_enabled(self.config):
+            try:
+                result = await process_aweme_transcript_async(
+                    aweme_id=aweme_id,
+                    save_dir=save_dir,
+                    file_stem=file_stem,
+                    mcp_cfg=mcp_cfg,
+                    video_path=video_path,
+                )
+                transcript_status = str(result.get("status") or "failed")
+                transcript_path = result.get("transcript_path")
+                if transcript_status == "skipped":
+                    logger.info(
+                        "MCP transcript skipped for aweme %s: %s",
+                        aweme_id,
+                        result.get("reason", "unknown"),
+                    )
+                elif transcript_status == "failed":
+                    logger.warning(
+                        "MCP transcript failed for aweme %s: %s",
+                        aweme_id,
+                        result.get("error", "unknown"),
+                    )
+                else:
+                    logger.info("MCP transcript ok for aweme %s", aweme_id)
+            except Exception as exc:  # noqa: BLE001
+                transcript_status = "failed"
+                transcript_path = str(transcript_txt_path(save_dir, file_stem))
+                logger.warning("MCP transcript hook crashed for %s: %s", aweme_id, exc)
+        else:
             transcript_result = await self.transcript_manager.process_video(
                 video_path, aweme_id=aweme_id
             )
-            transcript_status = transcript_result.get("status")
+            transcript_status = str(transcript_result.get("status") or "skipped")
             if transcript_status == "skipped":
                 logger.info(
                     "Transcript skipped for aweme %s: %s",
@@ -764,11 +839,27 @@ class BaseDownloader(ABC):
                     aweme_id,
                     transcript_result.get("error", "unknown"),
                 )
+            # Built-in manager writes its own sidecar names; factory still
+            # records the conventional stem path if present.
+            candidate = transcript_txt_path(save_dir, file_stem)
+            if candidate.is_file():
+                transcript_path = str(candidate)
 
-        if primary_media_downloaded:
-            self._mark_local_aweme_downloaded(aweme_id)
-        logger.info("Downloaded selected assets for %s: %s (%s)", media_type, desc, aweme_id)
-        return True
+        try:
+            media_root = Path(self.file_manager.base_path)
+            effective_title = (title or "").strip() or title_from_stem(file_stem, aweme_id)
+            record = build_factory_record(
+                aweme_id=aweme_id,
+                author=author_name,
+                title=effective_title,
+                media_path=str(video_path),
+                transcript_path=transcript_path,
+                transcript_status=transcript_status,
+                source="cli",
+            )
+            append_factory_records(media_root, record)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Factory index append failed for %s: %s", aweme_id, exc)
 
     async def _download_with_retry(
         self,

--- a/core/metadata.py
+++ b/core/metadata.py
@@ -66,3 +66,18 @@ def extract_author_sec_uid(aweme: Optional[Mapping[str, Any]]) -> Optional[str]:
         return None
     sec_uid = sec_uid.strip()
     return sec_uid or None
+
+
+def extract_author_nickname(aweme: Optional[Mapping[str, Any]]) -> Optional[str]:
+    """Return ``aweme["author"]["nickname"]`` or ``None`` if unavailable."""
+
+    if not isinstance(aweme, Mapping):
+        return None
+    author = aweme.get("author")
+    if not isinstance(author, Mapping):
+        return None
+    nickname = author.get("nickname")
+    if not isinstance(nickname, str):
+        return None
+    nickname = nickname.strip()
+    return nickname or None

--- a/core/user_downloader.py
+++ b/core/user_downloader.py
@@ -4,6 +4,7 @@ import time
 from typing import Any, Callable, Dict, List, Optional, Set
 
 from core.downloader_base import BaseDownloader, DownloadResult
+from core.metadata import extract_author_nickname, extract_author_sec_uid
 from core.user_mode_registry import UserModeRegistry
 from utils.logger import setup_logger
 
@@ -257,6 +258,34 @@ class UserDownloader(BaseDownloader):
             return value.strip().lower() in {"1", "true", "yes", "on"}
         return bool(value)
 
+    def _collect_use_aweme_author_dir(self) -> bool:
+        """Whether collect/collectmix should land under each aweme's author."""
+        return self._as_bool(self.config.get("collect_use_aweme_author_dir", True))
+
+    def _resolve_save_author(
+        self,
+        aweme_data: Dict[str, Any],
+        *,
+        mode: str,
+        feed_author_name: str,
+        feed_author_sec_uid: Optional[str],
+    ) -> tuple:
+        """Pick directory author for one aweme.
+
+        For collect/collectmix with ``collect_use_aweme_author_dir`` (default
+        on), use the original content author so paths match Douzy's
+        ``author_dir: nickname`` layout instead of ``self/collect/...``.
+        """
+        normalized = (mode or "").strip()
+        if normalized in self.SELF_COLLECT_MODES and self._collect_use_aweme_author_dir():
+            nickname = extract_author_nickname(aweme_data)
+            sec_uid = extract_author_sec_uid(aweme_data)
+            return (
+                nickname or feed_author_name or "unknown",
+                sec_uid or feed_author_sec_uid,
+            )
+        return (feed_author_name or "unknown", feed_author_sec_uid)
+
     async def _resolve_user_info(self, sec_uid: str, modes: List[str]) -> Optional[Dict[str, Any]]:
         normalized_modes = {str(mode or "").strip() for mode in modes}
         if sec_uid == "self" and normalized_modes.issubset(self.SELF_COLLECT_MODES):
@@ -367,12 +396,18 @@ class UserDownloader(BaseDownloader):
 
         async def _process_aweme(item: Dict[str, Any]):
             aweme_id = item.get("aweme_id")
+            dir_author_name, dir_author_sec_uid = self._resolve_save_author(
+                item,
+                mode=mode,
+                feed_author_name=author_name,
+                feed_author_sec_uid=author_sec_uid,
+            )
             if not await self._should_download(str(aweme_id or "")):
                 saved = await self._collect_comments_for_existing_aweme(
                     item,
-                    author_name,
+                    dir_author_name,
                     mode,
-                    author_sec_uid=author_sec_uid,
+                    author_sec_uid=dir_author_sec_uid,
                 )
                 status = "success" if saved else "skipped"
                 self._progress_advance_item(status, str(aweme_id or "unknown"))
@@ -380,10 +415,10 @@ class UserDownloader(BaseDownloader):
 
             success = await self._download_aweme_assets(
                 item,
-                author_name,
+                dir_author_name,
                 mode=mode,
                 db_batch=db_batch,
-                author_sec_uid=author_sec_uid,
+                author_sec_uid=dir_author_sec_uid,
             )
             status = "success" if success else "failed"
             self._progress_advance_item(status, str(aweme_id or "unknown"))

--- a/local_pipeline/__init__.py
+++ b/local_pipeline/__init__.py
@@ -1,0 +1,17 @@
+"""Production local pipeline (MCP transcript + factory index)."""
+
+from local_pipeline.mcp_transcript import (
+    append_factory_records,
+    build_factory_record,
+    mcp_transcript_enabled,
+    process_aweme_transcript,
+    process_aweme_transcript_async,
+)
+
+__all__ = [
+    "append_factory_records",
+    "build_factory_record",
+    "mcp_transcript_enabled",
+    "process_aweme_transcript",
+    "process_aweme_transcript_async",
+]

--- a/local_pipeline/mcp_transcript.py
+++ b/local_pipeline/mcp_transcript.py
@@ -1,0 +1,555 @@
+"""MCP extract_text hook + ``_factory`` index (production transcript path).
+
+Built-in Douzy ``TranscriptManager`` stays off; this module calls
+``douyin-mcp-server`` ``extract_text`` via the MCP venv (subprocess),
+writes ``{stem}.transcript.txt`` next to the downloaded media, and
+appends ``_factory`` manifest/delta rows.
+
+API key: prefer env ``DOUYIN_API_KEY``, then ``API_KEY`` / ``OPENAI_API_KEY``
+(aligned with MCP / SiliconFlow). Never log or commit the key.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+from utils.logger import setup_logger
+
+logger = setup_logger("McpTranscript")
+
+DEFAULT_MCP_SCRIPTS = (
+    r"D:\dev\github\douyin-mcp-server\douyin-video\scripts"
+)
+DEFAULT_MCP_PYTHON = r"D:\dev\github\douyin-mcp-server\.venv\Scripts\python.exe"
+
+# Fixed UTC+8 (Asia/Shanghai has no DST). Avoids Windows tzdata dependency.
+FACTORY_TZ = timezone(timedelta(hours=8))
+
+_EXTRACT_WORKER = r"""
+import json
+import os
+import sys
+
+scripts = sys.argv[1]
+share = sys.argv[2]
+api_key = sys.argv[3]
+sys.path.insert(0, scripts)
+os.environ.setdefault("DOUYIN_API_KEY", api_key)
+from douyin_downloader import extract_text
+
+result = extract_text(
+    share,
+    api_key=api_key,
+    output_dir=None,
+    save_video=False,
+    show_progress=False,
+)
+text = (result or {}).get("text") or ""
+sys.stdout.write(json.dumps({"text": text}, ensure_ascii=False))
+"""
+
+# Prefer local mp4: skip fragile HTML/share parse (videoInfoRes / _ROUTER_DATA).
+_EXTRACT_LOCAL_WORKER = r"""
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+scripts = sys.argv[1]
+video = sys.argv[2]
+api_key = sys.argv[3]
+sys.path.insert(0, scripts)
+os.environ.setdefault("DOUYIN_API_KEY", api_key)
+os.environ.setdefault("API_KEY", api_key)
+from douyin_downloader import DouyinProcessor
+
+processor = DouyinProcessor(api_key)
+src = Path(video)
+if not src.is_file():
+    raise FileNotFoundError(f"local video missing: {src}")
+# Hardlink/copy into processor temp so sidecar mp3 never lands in media root.
+local = processor.temp_dir / src.name
+try:
+    os.link(str(src), str(local))
+except OSError:
+    shutil.copy2(src, local)
+audio_path = processor.extract_audio(local, show_progress=False)
+text = processor.extract_text_from_audio(audio_path, show_progress=False) or ""
+sys.stdout.write(json.dumps({"text": text, "via": "local_video"}, ensure_ascii=False))
+"""
+
+_HTML_PARSE_FAILURE_RE = re.compile(
+    r"(从HTML中解析视频信息失败|videoInfoRes|_ROUTER_DATA|无法从JSON中解析视频)",
+    re.IGNORECASE,
+)
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def mcp_transcript_enabled(config: Any) -> bool:
+    raw = None
+    if hasattr(config, "get"):
+        raw = config.get("mcp_transcript")
+    elif isinstance(config, dict):
+        raw = config.get("mcp_transcript")
+    if not isinstance(raw, dict):
+        return False
+    return _as_bool(raw.get("enabled"), default=False)
+
+
+def resolve_api_key(mcp_cfg: Optional[Dict[str, Any]] = None) -> Optional[str]:
+    cfg = mcp_cfg or {}
+    names = []
+    primary = str(cfg.get("api_key_env") or "DOUYIN_API_KEY").strip()
+    if primary:
+        names.append(primary)
+    for name in ("DOUYIN_API_KEY", "API_KEY", "OPENAI_API_KEY"):
+        if name not in names:
+            names.append(name)
+    for name in names:
+        value = os.environ.get(name)
+        if value and str(value).strip():
+            return str(value).strip()
+    return None
+
+
+def transcript_txt_path(save_dir: Path, file_stem: str) -> Path:
+    return Path(save_dir) / f"{file_stem}.transcript.txt"
+
+
+def transcript_err_path(save_dir: Path, file_stem: str) -> Path:
+    return Path(save_dir) / f"{file_stem}.transcript.err.txt"
+
+
+def share_link_for_aweme(aweme_id: str) -> str:
+    return f"https://www.douyin.com/video/{aweme_id}"
+
+
+def _existing_nonempty_transcript(path: Path) -> bool:
+    try:
+        if not path.is_file():
+            return False
+        return bool(path.read_text(encoding="utf-8").strip())
+    except OSError:
+        return False
+
+
+def factory_day_key(ts: Optional[str] = None) -> str:
+    """Local calendar day (UTC+8) for ``delta-YYYY-MM-DD.jsonl`` filenames.
+
+    ``ts`` may be ISO-8601 (``...Z`` or offset). Falls back to now in UTC+8.
+    """
+    if ts:
+        raw = str(ts).strip()
+        try:
+            if raw.endswith("Z"):
+                raw = raw[:-1] + "+00:00"
+            dt = datetime.fromisoformat(raw)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(FACTORY_TZ).strftime("%Y-%m-%d")
+        except ValueError:
+            pass
+    return datetime.now(FACTORY_TZ).strftime("%Y-%m-%d")
+
+
+def _run_mcp_worker(
+    worker: str,
+    arg: str,
+    *,
+    api_key: str,
+    mcp_scripts_path: str,
+    mcp_python: str,
+    timeout_seconds: int = 600,
+) -> str:
+    scripts = str(Path(mcp_scripts_path).resolve())
+    python_exe = str(Path(mcp_python).resolve()) if mcp_python else sys.executable
+    if not Path(python_exe).is_file():
+        raise FileNotFoundError(f"MCP python not found: {python_exe}")
+    if not (Path(scripts) / "douyin_downloader.py").is_file():
+        raise FileNotFoundError(f"MCP scripts missing douyin_downloader.py: {scripts}")
+
+    completed = subprocess.run(
+        [python_exe, "-c", worker, scripts, arg, api_key],
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+        check=False,
+    )
+    if completed.returncode != 0:
+        err = (completed.stderr or completed.stdout or "").strip()
+        raise RuntimeError(err or f"extract worker exit {completed.returncode}")
+
+    stdout = (completed.stdout or "").strip()
+    if not stdout:
+        raise RuntimeError("extract worker returned empty stdout")
+    payload = json.loads(stdout)
+    text = payload.get("text") if isinstance(payload, dict) else None
+    if not isinstance(text, str) or not text.strip():
+        raise RuntimeError("extract worker returned empty text")
+    return text.strip()
+
+
+def call_extract_text(
+    share_link: str,
+    *,
+    api_key: str,
+    mcp_scripts_path: str,
+    mcp_python: str,
+    timeout_seconds: int = 600,
+) -> str:
+    """Invoke MCP ``extract_text`` via share URL (HTML parse + re-download)."""
+    return _run_mcp_worker(
+        _EXTRACT_WORKER,
+        share_link,
+        api_key=api_key,
+        mcp_scripts_path=mcp_scripts_path,
+        mcp_python=mcp_python,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def call_extract_text_from_local_video(
+    video_path: str,
+    *,
+    api_key: str,
+    mcp_scripts_path: str,
+    mcp_python: str,
+    timeout_seconds: int = 600,
+) -> str:
+    """ASR from an already-downloaded mp4 (no HTML / videoInfoRes).
+
+    Temp audio stays under MCP ``DouyinProcessor.temp_dir`` and is cleaned on
+    process exit — never written into the media root.
+    """
+    return _run_mcp_worker(
+        _EXTRACT_LOCAL_WORKER,
+        str(video_path),
+        api_key=api_key,
+        mcp_scripts_path=mcp_scripts_path,
+        mcp_python=mcp_python,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def _is_html_parse_failure(message: str) -> bool:
+    return bool(_HTML_PARSE_FAILURE_RE.search(message or ""))
+
+
+def process_aweme_transcript(
+    *,
+    aweme_id: str,
+    save_dir: Path,
+    file_stem: str,
+    mcp_cfg: Optional[Dict[str, Any]] = None,
+    extract_fn: Optional[Callable[..., str]] = None,
+    video_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Sync entry: write transcript sidecar; never raise for caller download.
+
+    When ``video_path`` exists, prefer local ASR (stable). Share-URL extract is
+    only used when local media is missing, or as a no-op path for injected
+    ``extract_fn`` tests. HTML / ``videoInfoRes`` failures fall back to local.
+
+    Returns dict with ``status`` in pending|ok|failed|skipped and paths.
+    """
+    cfg = dict(mcp_cfg or {})
+    txt_path = transcript_txt_path(save_dir, file_stem)
+    err_path = transcript_err_path(save_dir, file_stem)
+    local_video: Optional[Path] = None
+    if video_path is not None:
+        candidate = Path(video_path)
+        if candidate.is_file():
+            local_video = candidate
+    if local_video is None:
+        guessed = Path(save_dir) / f"{file_stem}.mp4"
+        if guessed.is_file():
+            local_video = guessed
+
+    if _existing_nonempty_transcript(txt_path):
+        return {
+            "status": "skipped",
+            "reason": "existing_transcript",
+            "transcript_path": str(txt_path),
+            "error_path": None,
+        }
+
+    api_key = resolve_api_key(cfg)
+    if not api_key:
+        message = (
+            "missing API key: set DOUYIN_API_KEY (or API_KEY / OPENAI_API_KEY)"
+        )
+        try:
+            err_path.write_text(message + "\n", encoding="utf-8")
+        except OSError:
+            pass
+        return {
+            "status": "failed",
+            "reason": "missing_api_key",
+            "transcript_path": str(txt_path),
+            "error_path": str(err_path),
+            "error": message,
+        }
+
+    scripts = str(cfg.get("mcp_scripts_path") or DEFAULT_MCP_SCRIPTS)
+    python_exe = str(cfg.get("mcp_python") or DEFAULT_MCP_PYTHON)
+    timeout = int(cfg.get("timeout_seconds") or 600)
+    link = share_link_for_aweme(aweme_id)
+    prefer_local = _as_bool(cfg.get("prefer_local_video"), default=True)
+
+    def _write_ok(text: str, *, via: str) -> Dict[str, Any]:
+        txt_path.write_text(text + "\n", encoding="utf-8")
+        if err_path.is_file():
+            try:
+                err_path.unlink()
+            except OSError:
+                pass
+        return {
+            "status": "ok",
+            "via": via,
+            "transcript_path": str(txt_path),
+            "error_path": None,
+        }
+
+    last_error = ""
+    try:
+        # Injected extract_fn: keep single-path behavior for unit tests.
+        if extract_fn is not None:
+            text = extract_fn(
+                link,
+                api_key=api_key,
+                mcp_scripts_path=scripts,
+                mcp_python=python_exe,
+                timeout_seconds=timeout,
+            )
+            return _write_ok(text, via="extract_fn")
+
+        attempted_local = False
+
+        if prefer_local and local_video is not None:
+            attempted_local = True
+            try:
+                text = call_extract_text_from_local_video(
+                    str(local_video),
+                    api_key=api_key,
+                    mcp_scripts_path=scripts,
+                    mcp_python=python_exe,
+                    timeout_seconds=timeout,
+                )
+                return _write_ok(text, via="local_video")
+            except Exception as local_exc:  # noqa: BLE001
+                last_error = (
+                    f"local_video: "
+                    f"{str(local_exc).strip() or local_exc.__class__.__name__}"
+                )
+                logger.warning(
+                    "Local ASR failed for aweme %s, trying share URL: %s",
+                    aweme_id,
+                    last_error[:200],
+                )
+
+        try:
+            text = call_extract_text(
+                link,
+                api_key=api_key,
+                mcp_scripts_path=scripts,
+                mcp_python=python_exe,
+                timeout_seconds=timeout,
+            )
+            via = "share_url"
+            if attempted_local and last_error:
+                via = "share_url_after_local_fail"
+            return _write_ok(text, via=via)
+        except Exception as share_exc:  # noqa: BLE001
+            share_msg = str(share_exc).strip() or share_exc.__class__.__name__
+            last_error = (
+                f"{last_error} | share_url: {share_msg}" if last_error else share_msg
+            )
+            if (
+                local_video is not None
+                and not attempted_local
+                and _is_html_parse_failure(share_msg)
+            ):
+                try:
+                    text = call_extract_text_from_local_video(
+                        str(local_video),
+                        api_key=api_key,
+                        mcp_scripts_path=scripts,
+                        mcp_python=python_exe,
+                        timeout_seconds=timeout,
+                    )
+                    logger.info(
+                        "MCP transcript recovered via local video for aweme %s",
+                        aweme_id,
+                    )
+                    return _write_ok(text, via="local_video_fallback")
+                except Exception as local_exc:  # noqa: BLE001
+                    last_error = (
+                        f"{last_error} | local_fallback: "
+                        f"{str(local_exc).strip() or local_exc.__class__.__name__}"
+                    )
+
+        message = last_error
+        if api_key and api_key in message:
+            message = message.replace(api_key, "***")
+        try:
+            err_path.write_text(message[:2000] + "\n", encoding="utf-8")
+        except OSError:
+            pass
+        logger.warning("MCP transcript failed for aweme %s: %s", aweme_id, message[:200])
+        return {
+            "status": "failed",
+            "reason": "extract_failed",
+            "transcript_path": str(txt_path),
+            "error_path": str(err_path),
+            "error": message[:500],
+        }
+    except Exception as exc:  # noqa: BLE001 — last-resort guard
+        message = str(exc).strip() or exc.__class__.__name__
+        if api_key and api_key in message:
+            message = message.replace(api_key, "***")
+        try:
+            err_path.write_text(message[:2000] + "\n", encoding="utf-8")
+        except OSError:
+            pass
+        logger.warning("MCP transcript failed for aweme %s: %s", aweme_id, message[:200])
+        return {
+            "status": "failed",
+            "reason": "extract_failed",
+            "transcript_path": str(txt_path),
+            "error_path": str(err_path),
+            "error": message[:500],
+        }
+
+
+def title_from_stem(file_stem: str, aweme_id: str = "") -> str:
+    """Best-effort title from ``{date}_{title}_{id}`` stem when API desc missing."""
+    stem = (file_stem or "").strip()
+    if not stem:
+        return ""
+    text = stem
+    # strip leading YYYY-MM-DD_
+    if len(text) >= 11 and text[4] == "-" and text[7] == "-" and text[10] == "_":
+        text = text[11:]
+    aid = (aweme_id or "").strip()
+    if aid and text.endswith("_" + aid):
+        text = text[: -(len(aid) + 1)]
+    elif aid and text.endswith(aid):
+        text = text[: -len(aid)].rstrip("_")
+    return text.strip(" _-")[:200]
+
+
+async def _run_in_thread(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Thread offload compatible with Python 3.8 (no ``asyncio.to_thread``)."""
+    to_thread = getattr(asyncio, "to_thread", None)
+    if to_thread is not None:
+        return await to_thread(func, *args, **kwargs)
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, lambda: func(*args, **kwargs))
+
+
+async def process_aweme_transcript_async(
+    *,
+    aweme_id: str,
+    save_dir: Path,
+    file_stem: str,
+    mcp_cfg: Optional[Dict[str, Any]] = None,
+    extract_fn: Optional[Callable[..., str]] = None,
+    video_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    return await _run_in_thread(
+        process_aweme_transcript,
+        aweme_id=aweme_id,
+        save_dir=save_dir,
+        file_stem=file_stem,
+        mcp_cfg=mcp_cfg,
+        extract_fn=extract_fn,
+        video_path=video_path,
+    )
+
+
+def content_hash_for(
+    aweme_id: str,
+    transcript_status: str,
+    transcript_path: Optional[str] = None,
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(aweme_id.encode("utf-8"))
+    digest.update(b"|")
+    digest.update(transcript_status.encode("utf-8"))
+    if transcript_path:
+        path = Path(transcript_path)
+        if path.is_file():
+            try:
+                digest.update(b"|")
+                digest.update(path.read_bytes()[:65536])
+            except OSError:
+                pass
+    return digest.hexdigest()[:16]
+
+
+def append_factory_records(
+    media_root: Path,
+    record: Dict[str, Any],
+) -> None:
+    """Append one JSONL line to manifest.jsonl and delta-YYYY-MM-DD.jsonl.
+
+    Day key is **Asia/Shanghai (UTC+8) local calendar date**, matching
+    ``ingest-douyin-delta.ps1`` ``(Get-Date)`` — not the UTC prefix of ``ts``.
+    """
+    factory_dir = Path(media_root) / "_factory"
+    factory_dir.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record, ensure_ascii=False) + "\n"
+    day_key = factory_day_key(record.get("ts"))
+
+    manifest = factory_dir / "manifest.jsonl"
+    delta = factory_dir / f"delta-{day_key}.jsonl"
+    with manifest.open("a", encoding="utf-8") as handle:
+        handle.write(line)
+    with delta.open("a", encoding="utf-8") as handle:
+        handle.write(line)
+
+
+def build_factory_record(
+    *,
+    aweme_id: str,
+    author: str,
+    title: str,
+    media_path: str,
+    transcript_path: Optional[str],
+    transcript_status: str,
+    source: str = "cli",
+    op: str = "upsert",
+) -> Dict[str, Any]:
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return {
+        "ts": ts,
+        "op": op,
+        "aweme_id": aweme_id,
+        "author": author or "",
+        "title": title or "",
+        "media_path": media_path,
+        "transcript_path": transcript_path or "",
+        "transcript_status": transcript_status,
+        "source": source,
+        "content_hash": content_hash_for(aweme_id, transcript_status, transcript_path),
+        "ref_id": f"MED-{aweme_id}",
+    }

--- a/scripts/SCHEDULED-TASK.md
+++ b/scripts/SCHEDULED-TASK.md
@@ -1,0 +1,97 @@
+# Task Scheduler recipe (M2) — Douyin favorites daily
+
+Do **not** run as SYSTEM if G: is a user-mapped drive; register under your login.
+
+## Trigger (current)
+
+**每天本地时间 03:00**（`StartWhenAvailable` + `WakeToRun`）。  
+要求：到点时用户会话仍在（锁屏可以；完全注销可能不跑 Interactive 任务）。G: 须已映射可写。
+
+一键（重）注册（Access Denied 时用管理员 PowerShell）：
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File D:\dev\github\douyin-downloader\scripts\register-DouyinFavoritesDaily.ps1
+```
+
+## Manual register snippet
+
+```powershell
+$script = 'D:\dev\github\douyin-downloader\scripts\daily-favorites.ps1'
+$action = New-ScheduledTaskAction `
+  -Execute 'powershell.exe' `
+  -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$script`""
+$trigger = New-ScheduledTaskTrigger -Daily -At '3:00AM'
+$settings = New-ScheduledTaskSettingsSet `
+  -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -WakeToRun
+$principal = New-ScheduledTaskPrincipal -UserId "$env:USERDOMAIN\$env:USERNAME" -LogonType Interactive -RunLevel Limited
+Register-ScheduledTask `
+  -TaskName 'DouyinFavoritesDaily' `
+  -Action $action -Trigger $trigger -Settings $settings -Principal $principal `
+  -Description 'Douyin favorites daily 03:00 → MCP transcript → _factory (+ ghaishu ingest)' `
+  -Force
+```
+
+## Manual / WhatIf
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File D:\dev\github\douyin-downloader\scripts\daily-favorites.ps1 -CollectLimit 5
+# Skip ghaishu projection:
+powershell -NoProfile -ExecutionPolicy Bypass -File D:\dev\github\douyin-downloader\scripts\daily-favorites.ps1 -SkipIngest
+```
+
+Layout (production daily): `G:\media\douyin\<原作者>\{date}_{title}_{id}\`  
+(`collect_use_aweme_author_dir=true`, `group_by_mode=false` — no `self` / no `collect` layer)
+
+## 存量补洞
+
+日更对**已落盘** aweme 会 skip 下载，因而**不会**触发 MCP hook。
+
+### 单条
+
+见 `LOCAL_SETUP.md`「存量补洞」，入口：`tools/run_mcp_transcript.py`（须显式 `--video` / `--aweme-id`）。
+
+### 按 delta 批量（推荐：修复 HTML/`videoInfoRes` 失败后的存量）
+
+只读 `_factory/delta-*.jsonl` 中的 `failed` 行（**不**递归扫媒体库）：
+
+```powershell
+cd D:\dev\github\douyin-downloader
+.\.venv\Scripts\python.exe tools\backfill_failed_from_delta.py `
+  --delta G:\media\douyin\_factory\delta-2026-08-09.jsonl
+# 投影到当日 handoff（本地日键）：
+powershell -NoProfile -ExecutionPolicy Bypass -File D:\ghaishu\.scripts\ingest-douyin-delta.ps1
+```
+
+生产转写默认 **prefer local mp4 ASR**（跳过脆弱的分享页 HTML / `videoInfoRes`）；若本地文件无音轨或抽音失败，自动回退 share URL 重拉再 ASR（`via=share_url_after_local_fail`）。
+
+长片若出现硅基 `500`（`.transcript.err.txt`）：下载仍算成功；稍后重跑 `run_mcp_transcript.py` / backfill 即可。
+
+## 观测约定（P2）
+
+**权威回放面 = 应用日志**，不是 Task Scheduler Operational 频道。
+
+| 信号 | 路径 / 含义 |
+|------|-------------|
+| 应用日志 | `%LOCALAPPDATA%\douyin-downloader-daily\logs\YYYYMMDD.log` |
+| 成功戳 | `G:\media\douyin\_factory\LAST_OK`（ISO 本地时间） |
+| 降级戳 | `G:\media\douyin\_factory\LAST_DEGRADED`（缺 delta / 转写全失败 / ingest 失败时写入；成功跑会删除） |
+| 日键 delta | `G:\media\douyin\_factory\delta-YYYY-MM-DD.jsonl`（**本地 UTC+8 日历日**，与 ingest 一致） |
+| ghaishu handoff | `D:\ghaishu\01-topics\refs\media-ingest\YYYY-MM-DD.md` |
+| 计划任务结果 | `Get-ScheduledTaskInfo '\DouyinFavoritesDaily'` → `LastTaskResult`（0=业务成功；6/7/8=业务失败，见 `daily-favorites.ps1` 头注释） |
+
+`Microsoft-Windows-TaskScheduler/Operational` 在本机可能为 **disabled**。不要求启用；排障优先读应用日志 + `LAST_*` + delta。若需启用：
+
+```powershell
+# 可选；非本流水线前置条件
+wevtutil sl Microsoft-Windows-TaskScheduler/Operational /e:true
+```
+
+## Cookie renewal
+
+Only maintain `%APPDATA%\Douzy\.cookies.json` (Douzy login or cookie_fetcher).  
+Logs: `%LOCALAPPDATA%\douyin-downloader-daily\logs\YYYYMMDD.log`
+
+## API key
+
+Prefer `DOUYIN_API_KEY` env. Else `API_KEY` / `OPENAI_API_KEY`.  
+If unset, the script may load Douzy `transcript.api_key` into the **process env only** (never git).

--- a/scripts/daily-favorites.ps1
+++ b/scripts/daily-favorites.ps1
@@ -1,0 +1,214 @@
+<#
+.SYNOPSIS
+  Daily favorites ingest: Douyin collect increase → MCP transcript hook → _factory index.
+
+.DESCRIPTION
+  Production scheduler entry (D1). Reuses %APPDATA%\Douzy\config.yml + .cookies.json
+  and media root G:\media\douyin. Built-in Douzy transcript stays false; MCP extract
+  runs via mcp_transcript.enabled in the merged overlay.
+
+  API key (D6): prefer process env DOUYIN_API_KEY, else API_KEY / OPENAI_API_KEY.
+  If still empty, optionally load Douzy transcript.api_key into *this process only*
+  (never written to git / logs).
+
+  Exit codes (business-visible; scheduler LastTaskResult):
+    0  — CLI ok, today's delta present, transcripts not all-failed, ingest ok
+    2  — media root missing/unwritable
+    3  — Douzy cookies/config missing
+    4  — repo/venv/overlay missing
+    5  — merge config failed
+    6  — today's delta missing or empty after CLI (projection would no-op)
+    7  — delta present but every new row transcript_status=failed
+    8  — ingest failed / wrote LAST_DEGRADED
+    other — CLI non-zero passthrough
+
+.NOTES
+  Scheduler: daily 03:00 local. Register/update via:
+    scripts\register-DouyinFavoritesDaily.ps1
+  (admin PowerShell if Access Denied). See scripts\SCHEDULED-TASK.md.
+
+  Cookie renewal: only maintain %APPDATA%\Douzy\.cookies.json (Douzy login or cookie_fetcher).
+#>
+[CmdletBinding()]
+param(
+    [switch]$SkipIngest,
+    [int]$CollectLimit = 20,
+    [string]$MediaRoot = 'G:\media\douyin',
+    [string]$RepoRoot = 'D:\dev\github\douyin-downloader',
+    [string]$GhaishuRoot = 'D:\ghaishu'
+)
+
+$ErrorActionPreference = 'Stop'
+$DouzyDir = Join-Path $env:APPDATA 'Douzy'
+$DouzyConfig = Join-Path $DouzyDir 'config.yml'
+$DouzyCookies = Join-Path $DouzyDir '.cookies.json'
+$DouzyDb = Join-Path $DouzyDir 'dy_downloader.db'
+$OverlaySrc = Join-Path $RepoRoot 'config.automation.yml'
+$LogDir = Join-Path $env:LOCALAPPDATA 'douyin-downloader-daily\logs'
+$FactoryDir = Join-Path $MediaRoot '_factory'
+$day = Get-Date -Format 'yyyyMMdd'
+$localDate = Get-Date -Format 'yyyy-MM-dd'
+$logFile = Join-Path $LogDir "$day.log"
+
+function Write-Log([string]$Message) {
+    $line = '[{0}] {1}' -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss'), $Message
+    Add-Content -LiteralPath $logFile -Value $line -Encoding UTF8
+    Write-Host $line
+}
+
+function Write-Degraded([string]$Reason, [int]$Code) {
+    $degraded = Join-Path $FactoryDir 'LAST_DEGRADED'
+    $payload = @(
+        "ts=$((Get-Date).ToString('o'))"
+        "local_date=$localDate"
+        "code=$Code"
+        "reason=$Reason"
+    ) -join "`n"
+    Set-Content -LiteralPath $degraded -Value $payload -Encoding utf8
+    Write-Log "LAST_DEGRADED written: $degraded ($Reason)"
+}
+
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+New-Item -ItemType Directory -Force -Path $FactoryDir | Out-Null
+
+Write-Log '=== daily-favorites start ==='
+
+if (-not (Test-Path -LiteralPath $MediaRoot)) {
+    Write-Log "FAIL: media root missing or unmapped: $MediaRoot"
+    exit 2
+}
+try {
+    $probe = Join-Path $FactoryDir ('.write_probe_{0}' -f $PID)
+    Set-Content -LiteralPath $probe -Value 'ok' -Encoding ascii
+    Remove-Item -LiteralPath $probe -Force
+} catch {
+    Write-Log "FAIL: media root not writable: $MediaRoot ($_)"
+    exit 2
+}
+
+if (-not (Test-Path -LiteralPath $DouzyCookies)) {
+    Write-Log "FAIL: Douzy cookies missing: $DouzyCookies"
+    exit 3
+}
+if (-not (Test-Path -LiteralPath $DouzyConfig)) {
+    Write-Log "FAIL: Douzy config missing: $DouzyConfig"
+    exit 3
+}
+if (-not (Test-Path -LiteralPath $OverlaySrc)) {
+    Write-Log "FAIL: automation overlay missing: $OverlaySrc"
+    exit 4
+}
+
+$venvPython = Join-Path $RepoRoot '.venv\Scripts\python.exe'
+if (-not (Test-Path -LiteralPath $venvPython)) {
+    Write-Log "FAIL: venv python missing: $venvPython"
+    exit 4
+}
+
+# API key: env first; else Douzy transcript.api_key into this process only
+$hasKey = @('DOUYIN_API_KEY', 'API_KEY', 'OPENAI_API_KEY') | Where-Object {
+    -not [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_))
+}
+if (-not $hasKey) {
+    $reader = Join-Path $RepoRoot 'tools\_read_douzy_api_key_once.py'
+    if (Test-Path -LiteralPath $reader) {
+        $loaded = & $venvPython $reader 2>$null
+        if ($loaded) {
+            $env:DOUYIN_API_KEY = $loaded
+            Write-Log 'API key: loaded from Douzy config into process env (not logged)'
+        } else {
+            Write-Log 'WARN: no API key in env or Douzy config; transcripts will fail with .err.txt'
+        }
+    }
+} else {
+    Write-Log ("API key: using env {0}" -f ($hasKey -join ','))
+}
+
+$env:DOUYIN_MEDIA_ROOT = $MediaRoot
+# Put merged config beside Douzy cookies so cookie: auto finds .cookies.json
+$mergedConfig = Join-Path $DouzyDir 'config.daily.generated.yml'
+$mergeScript = Join-Path $RepoRoot 'tools\merge_daily_config.py'
+& $venvPython $mergeScript $DouzyConfig $OverlaySrc $mergedConfig $DouzyDb $CollectLimit
+if ($LASTEXITCODE -ne 0) {
+    Write-Log "FAIL: merge config exit $LASTEXITCODE"
+    exit 5
+}
+Write-Log "merged config: $mergedConfig"
+
+Push-Location $RepoRoot
+try {
+    Write-Log 'running CLI collect increase…'
+    & $venvPython -m cli.main --config $mergedConfig
+    $cliExit = $LASTEXITCODE
+} finally {
+    Pop-Location
+}
+
+if ($cliExit -ne 0) {
+    Write-Log "FAIL: CLI exit $cliExit"
+    exit $cliExit
+}
+
+# Business gate: local-day delta must exist and not be all-failed.
+$deltaPath = Join-Path $FactoryDir "delta-$localDate.jsonl"
+if (-not (Test-Path -LiteralPath $deltaPath)) {
+    Write-Degraded -Reason "missing_delta:$deltaPath" -Code 6
+    Remove-Item -LiteralPath $mergedConfig -Force -ErrorAction SilentlyContinue
+    Write-Log "FAIL: no local-day delta after CLI: $deltaPath"
+    exit 6
+}
+
+$statuses = @()
+Get-Content -LiteralPath $deltaPath -Encoding UTF8 | ForEach-Object {
+    $line = $_.Trim()
+    if (-not $line) { return }
+    try {
+        $obj = $line | ConvertFrom-Json
+        if ($obj.transcript_status) { $statuses += [string]$obj.transcript_status }
+    } catch { }
+}
+if ($statuses.Count -eq 0) {
+    Write-Degraded -Reason "empty_delta:$deltaPath" -Code 6
+    Remove-Item -LiteralPath $mergedConfig -Force -ErrorAction SilentlyContinue
+    Write-Log "FAIL: delta empty: $deltaPath"
+    exit 6
+}
+
+$failedCount = @($statuses | Where-Object { $_ -eq 'failed' }).Count
+$okCount = @($statuses | Where-Object { $_ -eq 'ok' -or $_ -eq 'skipped' }).Count
+Write-Log "delta $localDate rows=$($statuses.Count) ok_or_skipped=$okCount failed=$failedCount"
+
+if ($okCount -eq 0 -and $failedCount -gt 0) {
+    Write-Degraded -Reason "all_transcripts_failed:failed=$failedCount" -Code 7
+    Remove-Item -LiteralPath $mergedConfig -Force -ErrorAction SilentlyContinue
+    Write-Log "FAIL: all transcript rows failed ($failedCount); refusing success exit"
+    exit 7
+}
+
+$lastOk = Join-Path $FactoryDir 'LAST_OK'
+Set-Content -LiteralPath $lastOk -Value ((Get-Date).ToString('o')) -Encoding ascii
+$degradedPath = Join-Path $FactoryDir 'LAST_DEGRADED'
+if (Test-Path -LiteralPath $degradedPath) {
+    Remove-Item -LiteralPath $degradedPath -Force -ErrorAction SilentlyContinue
+}
+Write-Log "LAST_OK written: $lastOk"
+
+if (-not $SkipIngest) {
+    $ingest = Join-Path $GhaishuRoot '.scripts\ingest-douyin-delta.ps1'
+    if (Test-Path -LiteralPath $ingest) {
+        Write-Log "calling ingest-douyin-delta.ps1 -Date $localDate"
+        & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $ingest -Date $localDate
+        if ($LASTEXITCODE -ne 0) {
+            Write-Degraded -Reason "ingest_exit:$LASTEXITCODE" -Code 8
+            Remove-Item -LiteralPath $mergedConfig -Force -ErrorAction SilentlyContinue
+            Write-Log "FAIL: ingest exit $LASTEXITCODE"
+            exit 8
+        }
+    } else {
+        Write-Log "ingest script not found yet: $ingest"
+    }
+}
+
+Remove-Item -LiteralPath $mergedConfig -Force -ErrorAction SilentlyContinue
+Write-Log '=== daily-favorites ok ==='
+exit 0

--- a/scripts/download.ps1
+++ b/scripts/download.ps1
@@ -1,0 +1,13 @@
+# 下载一条抖音链接
+# 用法：.\scripts\download.ps1 -Url "https://v.douyin.com/xxxx"
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Url,
+    [string]$Path = ".\Downloaded",
+    [int]$Thread = 5
+)
+$ErrorActionPreference = "Stop"
+Set-Location (Split-Path $PSScriptRoot -Parent)
+$py = Join-Path $PWD ".venv\Scripts\python.exe"
+& $py run.py -c config.yml -u $Url -p $Path -t $Thread -v
+exit $LASTEXITCODE

--- a/scripts/fetch-cookies.bat
+++ b/scripts/fetch-cookies.bat
@@ -1,0 +1,20 @@
+@echo off
+chcp 65001 >nul
+cd /d "%~dp0.."
+echo.
+echo ========================================
+echo  抖音 Cookie 采集
+echo ========================================
+echo  1) 将打开浏览器，请登录 douyin.com
+echo  2) 登录成功后回到【本黑窗口】按 Enter
+echo ========================================
+echo.
+".venv\Scripts\python.exe" -m tools.cookie_fetcher --config config.yml
+echo.
+if errorlevel 1 (
+  echo [失败] Cookie 采集未完成
+) else (
+  echo [完成] Cookie 已写入 config.yml 与 config\cookies.json
+)
+echo.
+pause

--- a/scripts/fetch-cookies.ps1
+++ b/scripts/fetch-cookies.ps1
@@ -1,0 +1,12 @@
+# 采集抖音 Cookie 并写回 config.yml
+# 用法：在仓库根目录执行  .\scripts\fetch-cookies.ps1
+$ErrorActionPreference = "Stop"
+Set-Location (Split-Path $PSScriptRoot -Parent)
+$py = Join-Path $PWD ".venv\Scripts\python.exe"
+if (-not (Test-Path $py)) {
+    Write-Error "未找到 .venv，请先在仓库根目录执行: uv venv .venv; uv pip install -r requirements.txt playwright fastapi uvicorn; .\.venv\Scripts\python.exe -m playwright install chromium"
+}
+Write-Host "将打开浏览器，请登录 douyin.com；登录完成后回到本终端按 Enter。" -ForegroundColor Cyan
+& $py -m tools.cookie_fetcher --config config.yml
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+Write-Host "Cookie 已写入 config.yml / config\cookies.json" -ForegroundColor Green

--- a/scripts/register-DouyinFavoritesDaily.ps1
+++ b/scripts/register-DouyinFavoritesDaily.ps1
@@ -1,0 +1,64 @@
+<#
+.SYNOPSIS
+  (Re)register DouyinFavoritesDaily for daily 03:00 local time.
+  Prefer: right-click → Run with PowerShell (as Admin if Access Denied).
+#>
+$ErrorActionPreference = 'Stop'
+$log = Join-Path $env:TEMP 'register-DouyinFavoritesDaily.log'
+function Log([string]$m) {
+  $line = '[{0}] {1}' -f (Get-Date -Format 's'), $m
+  Add-Content -LiteralPath $log -Value $line -Encoding UTF8
+  Write-Host $line
+}
+
+try {
+  $script = Join-Path $PSScriptRoot 'daily-favorites.ps1'
+  if (-not (Test-Path -LiteralPath $script)) { throw "Missing: $script" }
+
+  $userId = if ($env:USERDOMAIN) { "$env:USERDOMAIN\$env:USERNAME" } else { $env:USERNAME }
+  Log "Registering as UserId=$userId script=$script"
+
+  $action = New-ScheduledTaskAction `
+    -Execute 'powershell.exe' `
+    -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$script`""
+  $trigger = New-ScheduledTaskTrigger -Daily -At '3:00AM'
+  $settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable `
+    -WakeToRun
+  $principal = New-ScheduledTaskPrincipal `
+    -UserId $userId `
+    -LogonType Interactive `
+    -RunLevel Limited
+
+  $existing = Get-ScheduledTask -TaskName 'DouyinFavoritesDaily' -ErrorAction SilentlyContinue
+  if ($existing) {
+    Log 'Updating existing task (Set-ScheduledTask)'
+    Set-ScheduledTask `
+      -TaskName 'DouyinFavoritesDaily' `
+      -Action $action `
+      -Trigger $trigger `
+      -Settings $settings `
+      -Principal $principal | Out-Null
+  } else {
+    Log 'Creating new task (Register-ScheduledTask)'
+    Register-ScheduledTask `
+      -TaskName 'DouyinFavoritesDaily' `
+      -Action $action `
+      -Trigger $trigger `
+      -Settings $settings `
+      -Principal $principal `
+      -Description 'Douyin favorites daily 03:00 → MCP transcript → _factory (+ ghaishu ingest)' `
+      -Force | Out-Null
+  }
+
+  $t = Get-ScheduledTask -TaskName DouyinFavoritesDaily
+  $i = Get-ScheduledTaskInfo $t
+  Log "OK State=$($t.State) NextRun=$($i.NextRunTime) StartBoundary=$($t.Triggers[0].StartBoundary)"
+  exit 0
+} catch {
+  Log "FAIL: $($_.Exception.Message)"
+  Log $_.ScriptStackTrace
+  exit 1
+}

--- a/scripts/serve.ps1
+++ b/scripts/serve.ps1
@@ -1,0 +1,12 @@
+# 启动本地 REST API（默认 127.0.0.1:8000）
+# 用法：.\scripts\serve.ps1
+param(
+    [string]$HostName = "127.0.0.1",
+    [int]$Port = 8010
+)
+$ErrorActionPreference = "Stop"
+Set-Location (Split-Path $PSScriptRoot -Parent)
+$py = Join-Path $PWD ".venv\Scripts\python.exe"
+Write-Host "REST API: http://${HostName}:${Port}/api/v1/health" -ForegroundColor Cyan
+& $py run.py -c config.yml --serve --serve-host $HostName --serve-port $Port
+exit $LASTEXITCODE

--- a/tests/test_collect_aweme_author_dir.py
+++ b/tests/test_collect_aweme_author_dir.py
@@ -1,0 +1,77 @@
+"""collect_use_aweme_author_dir: save under original author, not feed owner."""
+
+from control.queue_manager import QueueManager
+from core.user_downloader import UserDownloader
+from storage.file_manager import FileManager
+
+
+class _FakeConfig:
+    def __init__(self, data):
+        self._data = data
+
+    def get(self, key, default=None):
+        return self._data.get(key, default)
+
+
+def _downloader(tmp_path, **cfg_extra):
+    data = {
+        "mode": ["collect"],
+        "thread": 1,
+        "collect_use_aweme_author_dir": True,
+        "author_dir": "nickname",
+        "group_by_mode": True,
+        "folderstyle": True,
+    }
+    data.update(cfg_extra)
+    return UserDownloader(
+        config=_FakeConfig(data),
+        api_client=object(),
+        file_manager=FileManager(str(tmp_path / "Downloaded")),
+        cookie_manager=object(),
+        database=None,
+        rate_limiter=None,
+        retry_handler=None,
+        queue_manager=QueueManager(max_workers=1),
+    )
+
+
+def test_resolve_save_author_collect_uses_aweme_nickname(tmp_path):
+    dl = _downloader(tmp_path)
+    item = {
+        "aweme_id": "123",
+        "author": {"nickname": "刘小排", "sec_uid": "sec_liu"},
+    }
+    name, sec = dl._resolve_save_author(
+        item,
+        mode="collect",
+        feed_author_name="self",
+        feed_author_sec_uid="self",
+    )
+    assert name == "刘小排"
+    assert sec == "sec_liu"
+
+
+def test_resolve_save_author_collect_can_keep_feed_owner(tmp_path):
+    dl = _downloader(tmp_path, collect_use_aweme_author_dir=False)
+    item = {"aweme_id": "123", "author": {"nickname": "刘小排", "sec_uid": "sec_liu"}}
+    name, sec = dl._resolve_save_author(
+        item,
+        mode="collect",
+        feed_author_name="self",
+        feed_author_sec_uid="self",
+    )
+    assert name == "self"
+    assert sec == "self"
+
+
+def test_resolve_save_author_post_keeps_feed_owner(tmp_path):
+    dl = _downloader(tmp_path)
+    item = {"aweme_id": "123", "author": {"nickname": "别人", "sec_uid": "sec_x"}}
+    name, sec = dl._resolve_save_author(
+        item,
+        mode="post",
+        feed_author_name="博主A",
+        feed_author_sec_uid="sec_a",
+    )
+    assert name == "博主A"
+    assert sec == "sec_a"

--- a/tests/test_mcp_transcript_hook.py
+++ b/tests/test_mcp_transcript_hook.py
@@ -1,0 +1,157 @@
+"""Unit tests for MCP transcript hook (mocked extract_text; no network)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from local_pipeline import mcp_transcript as mt
+
+
+def test_skip_when_transcript_exists(tmp_path: Path):
+    stem = "2026-01-01_title_123"
+    txt = tmp_path / f"{stem}.transcript.txt"
+    txt.write_text("already here\n", encoding="utf-8")
+
+    def boom(*_a, **_k):
+        raise AssertionError("extract must not run")
+
+    result = mt.process_aweme_transcript(
+        aweme_id="123",
+        save_dir=tmp_path,
+        file_stem=stem,
+        mcp_cfg={"enabled": True},
+        extract_fn=boom,
+    )
+    assert result["status"] == "skipped"
+    assert result["reason"] == "existing_transcript"
+
+
+def test_missing_api_key_writes_err_and_does_not_raise(tmp_path: Path, monkeypatch):
+    for name in ("DOUYIN_API_KEY", "API_KEY", "OPENAI_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+
+    stem = "stem_456"
+    result = mt.process_aweme_transcript(
+        aweme_id="456",
+        save_dir=tmp_path,
+        file_stem=stem,
+        mcp_cfg={"api_key_env": "DOUYIN_API_KEY"},
+        extract_fn=lambda **_k: "nope",
+    )
+    assert result["status"] == "failed"
+    assert result["reason"] == "missing_api_key"
+    err = tmp_path / f"{stem}.transcript.err.txt"
+    assert err.is_file()
+    assert "missing API key" in err.read_text(encoding="utf-8")
+
+
+def test_extract_ok_writes_txt(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("DOUYIN_API_KEY", "sk-test-not-real")
+
+    def fake_extract(share_link, **_kwargs):
+        assert "789" in share_link
+        return "hello transcript"
+
+    stem = "stem_789"
+    result = mt.process_aweme_transcript(
+        aweme_id="789",
+        save_dir=tmp_path,
+        file_stem=stem,
+        mcp_cfg={},
+        extract_fn=fake_extract,
+    )
+    assert result["status"] == "ok"
+    txt = tmp_path / f"{stem}.transcript.txt"
+    assert txt.read_text(encoding="utf-8").strip() == "hello transcript"
+
+
+def test_extract_failure_writes_err(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("DOUYIN_API_KEY", "sk-test-not-real")
+
+    def fake_extract(*_args, **_kwargs):
+        raise RuntimeError("asr boom")
+
+    stem = "stem_fail"
+    result = mt.process_aweme_transcript(
+        aweme_id="fail1",
+        save_dir=tmp_path,
+        file_stem=stem,
+        mcp_cfg={},
+        extract_fn=fake_extract,
+    )
+    assert result["status"] == "failed"
+    err = tmp_path / f"{stem}.transcript.err.txt"
+    assert "asr boom" in err.read_text(encoding="utf-8")
+
+
+def test_factory_day_key_uses_shanghai_not_utc_prefix():
+    # 2026-08-10 03:00+08 == 2026-08-09 19:00Z — must map to local 08-10
+    assert mt.factory_day_key("2026-08-09T19:00:40Z") == "2026-08-10"
+    assert mt.factory_day_key("2026-08-10T01:00:00+08:00") == "2026-08-10"
+
+
+def test_factory_append_uses_local_day_key(tmp_path: Path):
+    media_root = tmp_path / "media"
+    media_root.mkdir()
+    record = mt.build_factory_record(
+        aweme_id="111",
+        author="a",
+        title="t",
+        media_path=str(media_root / "x.mp4"),
+        transcript_path=str(media_root / "x.transcript.txt"),
+        transcript_status="ok",
+    )
+    # Force a UTC evening ts that is next local morning
+    record["ts"] = "2026-08-09T19:00:40Z"
+    mt.append_factory_records(media_root, record)
+    factory = media_root / "_factory"
+    assert (factory / "delta-2026-08-10.jsonl").is_file()
+    assert not (factory / "delta-2026-08-09.jsonl").is_file()
+
+
+def test_html_parse_failure_detector():
+    assert mt._is_html_parse_failure("KeyError: 'videoInfoRes'")
+    assert mt._is_html_parse_failure("ValueError: 从HTML中解析视频信息失败")
+    assert not mt._is_html_parse_failure("asr boom")
+
+
+def test_factory_append(tmp_path: Path):
+    media_root = tmp_path / "media"
+    media_root.mkdir()
+    record = mt.build_factory_record(
+        aweme_id="111",
+        author="a",
+        title="t",
+        media_path=str(media_root / "x.mp4"),
+        transcript_path=str(media_root / "x.transcript.txt"),
+        transcript_status="ok",
+    )
+    mt.append_factory_records(media_root, record)
+    factory = media_root / "_factory"
+    assert (factory / "manifest.jsonl").is_file()
+    deltas = list(factory.glob("delta-*.jsonl"))
+    assert len(deltas) == 1
+    line = deltas[0].read_text(encoding="utf-8").strip()
+    assert "MED-111" in line
+    assert '"transcript_status": "ok"' in line
+
+
+def test_title_from_stem():
+    stem = "2026-06-06_哈喽大家好_7648284266559835402"
+    assert mt.title_from_stem(stem, "7648284266559835402") == "哈喽大家好"
+
+
+@pytest.mark.asyncio
+async def test_async_wrapper(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("DOUYIN_API_KEY", "sk-test")
+
+    result = await mt.process_aweme_transcript_async(
+        aweme_id="async1",
+        save_dir=tmp_path,
+        file_stem="async_stem",
+        mcp_cfg={},
+        extract_fn=lambda *_a, **_k: "async text",
+    )
+    assert result["status"] == "ok"

--- a/tests/test_metadata_author.py
+++ b/tests/test_metadata_author.py
@@ -1,0 +1,16 @@
+"""Tests for aweme author extraction helpers."""
+
+from core.metadata import extract_author_nickname, extract_author_sec_uid
+
+
+def test_extract_author_nickname_ok():
+    aweme = {"author": {"nickname": " 刘小排 ", "sec_uid": "MS4wLjABAAAAxxx"}}
+    assert extract_author_nickname(aweme) == "刘小排"
+    assert extract_author_sec_uid(aweme) == "MS4wLjABAAAAxxx"
+
+
+def test_extract_author_nickname_missing():
+    assert extract_author_nickname({}) is None
+    assert extract_author_nickname({"author": {}}) is None
+    assert extract_author_nickname({"author": {"nickname": "  "}}) is None
+    assert extract_author_nickname(None) is None

--- a/tools/_read_douzy_api_key_once.py
+++ b/tools/_read_douzy_api_key_once.py
@@ -1,0 +1,17 @@
+"""One-shot: print Douzy transcript.api_key to stdout (caller sets env). Do not commit output."""
+import os
+import re
+import sys
+from pathlib import Path
+
+cfg = Path(os.environ.get("DOUZY_CFG") or (Path(os.environ["APPDATA"]) / "Douzy" / "config.yml"))
+text = cfg.read_text(encoding="utf-8")
+match = re.search(r"(?m)^\s*api_key:\s*(\S+)\s*$", text)
+if not match:
+    sys.stderr.write("no api_key in Douzy config\n")
+    sys.exit(1)
+key = match.group(1).strip().strip("'\"")
+if not key:
+    sys.stderr.write("empty api_key\n")
+    sys.exit(1)
+sys.stdout.write(key)

--- a/tools/backfill_failed_from_delta.py
+++ b/tools/backfill_failed_from_delta.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Backfill MCP transcripts for failed rows listed in a factory delta JSONL.
+
+Reads only the given delta file (no recursive media-root scan). Prefer local
+mp4 ASR. Re-appends factory rows under today's Asia/Shanghai day key.
+
+Examples:
+  python tools/backfill_failed_from_delta.py --delta G:\\media\\douyin\\_factory\\delta-2026-08-09.jsonl
+  python tools/backfill_failed_from_delta.py --delta ... --limit 3 --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from local_pipeline.mcp_transcript import (  # noqa: E402
+    DEFAULT_MCP_PYTHON,
+    DEFAULT_MCP_SCRIPTS,
+    append_factory_records,
+    build_factory_record,
+    factory_day_key,
+    process_aweme_transcript,
+    title_from_stem,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Backfill failed transcripts from a delta JSONL")
+    parser.add_argument("--delta", type=Path, required=True)
+    parser.add_argument("--media-root", type=Path, default=Path(r"G:\media\douyin"))
+    parser.add_argument("--mcp-scripts", default=DEFAULT_MCP_SCRIPTS)
+    parser.add_argument("--mcp-python", default=DEFAULT_MCP_PYTHON)
+    parser.add_argument("--limit", type=int, default=0, help="Max rows to attempt (0=all)")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--statuses",
+        default="failed",
+        help="Comma-separated transcript_status to retry (default: failed)",
+    )
+    args = parser.parse_args()
+
+    if not args.delta.is_file():
+        print(f"delta missing: {args.delta}", file=sys.stderr)
+        return 2
+
+    want = {s.strip() for s in args.statuses.split(",") if s.strip()}
+    rows = []
+    for line in args.delta.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if str(obj.get("transcript_status") or "") not in want:
+            continue
+        if not obj.get("aweme_id") or not obj.get("media_path"):
+            continue
+        rows.append(obj)
+
+    # Latest row wins per aweme_id
+    by_id = {}
+    for obj in rows:
+        by_id[str(obj["aweme_id"])] = obj
+    items = list(by_id.values())
+    if args.limit and args.limit > 0:
+        items = items[: args.limit]
+
+    print(f"day_key_now={factory_day_key()} candidates={len(items)} dry_run={args.dry_run}")
+    ok = failed = skipped = 0
+    mcp_cfg = {
+        "mcp_scripts_path": args.mcp_scripts,
+        "mcp_python": args.mcp_python,
+        "prefer_local_video": True,
+    }
+
+    for obj in items:
+        aweme_id = str(obj["aweme_id"])
+        media_path = Path(str(obj["media_path"]))
+        if not media_path.is_file():
+            print(f"SKIP missing media {aweme_id}: {media_path}")
+            skipped += 1
+            continue
+        save_dir = media_path.parent
+        stem = media_path.stem
+        author = str(obj.get("author") or "")
+        title = str(obj.get("title") or "") or title_from_stem(stem, aweme_id)
+        print(f"TRY {aweme_id} {media_path.name}")
+        if args.dry_run:
+            continue
+
+        result = process_aweme_transcript(
+            aweme_id=aweme_id,
+            save_dir=save_dir,
+            file_stem=stem,
+            mcp_cfg=mcp_cfg,
+            video_path=media_path,
+        )
+        status = str(result.get("status") or "failed")
+        print(f"  status={status} via={result.get('via')} err={result.get('error')}")
+        if status == "skipped":
+            skipped += 1
+            continue
+        record = build_factory_record(
+            aweme_id=aweme_id,
+            author=author,
+            title=title,
+            media_path=str(media_path),
+            transcript_path=result.get("transcript_path"),
+            transcript_status=status,
+            source="backfill",
+        )
+        append_factory_records(args.media_root, record)
+        if status == "ok":
+            ok += 1
+        else:
+            failed += 1
+
+    print(f"done ok={ok} failed={failed} skipped={skipped}")
+    if args.dry_run:
+        return 0
+    if ok == 0 and failed > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/merge_daily_config.py
+++ b/tools/merge_daily_config.py
@@ -1,0 +1,66 @@
+"""Merge Douzy config.yml + config.automation.yml → daily generated yml."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def merge(base, overlay):
+    result = dict(base)
+    for key, value in overlay.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("douzy_config")
+    parser.add_argument("overlay")
+    parser.add_argument("out")
+    parser.add_argument("database_path")
+    parser.add_argument("collect_limit", type=int)
+    args = parser.parse_args()
+
+    def load(path: str):
+        return yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+
+    cfg = merge(load(args.douzy_config), load(args.overlay))
+    cfg["path"] = os.environ.get("DOUYIN_MEDIA_ROOT") or cfg.get("path") or r"G:\media\douyin"
+    cfg["cookie"] = "auto"
+    cfg["auto_cookie"] = True
+    cfg["database"] = True
+    cfg["database_path"] = args.database_path
+    cfg.setdefault("transcript", {})
+    cfg["transcript"]["enabled"] = False
+    cfg.setdefault("mcp_transcript", {})
+    cfg["mcp_transcript"]["enabled"] = True
+    cfg["mcp_transcript"].setdefault("prefer_local_video", True)
+    cfg.setdefault("number", {})
+    cfg["number"]["collect"] = args.collect_limit
+    cfg.setdefault("increase", {})
+    cfg["increase"]["collect"] = True
+    cfg["mode"] = ["collect"]
+    cfg["link"] = ["https://www.douyin.com/user/self"]
+    cfg["music"] = True
+    cfg["collect_use_aweme_author_dir"] = True
+    cfg["group_by_mode"] = False
+
+    out = Path(args.out)
+    out.write_text(
+        yaml.safe_dump(cfg, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+    print(str(out))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_mcp_transcript.py
+++ b/tools/run_mcp_transcript.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Backfill / hand-test MCP transcript for one already-downloaded aweme.
+
+Does not scan the whole media library: caller passes video path (or save_dir + stem).
+
+Examples:
+  python tools/run_mcp_transcript.py --aweme-id 7648284266559835402 --video G:\\media\\douyin\\...\\xxx.mp4
+  python tools/run_mcp_transcript.py --aweme-id 7665740374463705009 --save-dir DIR --stem FILE_STEM
+
+API key: DOUYIN_API_KEY (or API_KEY / OPENAI_API_KEY). Never pass keys on the CLI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Repo root on sys.path when run as script
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from local_pipeline.mcp_transcript import (  # noqa: E402
+    DEFAULT_MCP_PYTHON,
+    DEFAULT_MCP_SCRIPTS,
+    append_factory_records,
+    build_factory_record,
+    process_aweme_transcript,
+    title_from_stem,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="MCP extract_text backfill for one aweme")
+    parser.add_argument("--aweme-id", required=True)
+    parser.add_argument("--video", type=Path, help="Path to .mp4 (stem/dir inferred)")
+    parser.add_argument("--save-dir", type=Path)
+    parser.add_argument("--stem", type=str)
+    parser.add_argument("--author", default="")
+    parser.add_argument("--title", default="")
+    parser.add_argument(
+        "--media-root",
+        type=Path,
+        default=Path(r"G:\media\douyin"),
+        help="Root for _factory index append",
+    )
+    parser.add_argument("--mcp-scripts", default=DEFAULT_MCP_SCRIPTS)
+    parser.add_argument("--mcp-python", default=DEFAULT_MCP_PYTHON)
+    args = parser.parse_args()
+
+    if args.video:
+        video_path = args.video.resolve()
+        save_dir = video_path.parent
+        stem = video_path.stem
+        media_path = str(video_path)
+        if not args.author:
+            # author dir is typically parent of the aweme folder
+            try:
+                args.author = video_path.parent.parent.name
+            except Exception:
+                args.author = ""
+    elif args.save_dir and args.stem:
+        save_dir = args.save_dir.resolve()
+        stem = args.stem
+        media_path = str(save_dir / f"{stem}.mp4")
+    else:
+        parser.error("Provide --video or both --save-dir and --stem")
+        return 2
+
+    title = (args.title or "").strip() or title_from_stem(stem, args.aweme_id)
+
+    mcp_cfg = {
+        "mcp_scripts_path": args.mcp_scripts,
+        "mcp_python": args.mcp_python,
+    }
+    result = process_aweme_transcript(
+        aweme_id=args.aweme_id,
+        save_dir=save_dir,
+        file_stem=stem,
+        mcp_cfg=mcp_cfg,
+        video_path=Path(media_path) if Path(media_path).is_file() else None,
+    )
+    status = result.get("status")
+    print(f"status={status} path={result.get('transcript_path')}")
+    if result.get("error"):
+        print(f"error={result.get('error')}")
+
+    # Do not append a weaker "skipped" factory row that would clobber an earlier ok
+    # when ingest prefers last-write; still append for ok/failed.
+    if status == "skipped":
+        return 0
+
+    record = build_factory_record(
+        aweme_id=args.aweme_id,
+        author=args.author,
+        title=title,
+        media_path=media_path,
+        transcript_path=result.get("transcript_path"),
+        transcript_status=str(status or "failed"),
+        source="backfill",
+    )
+    append_factory_records(args.media_root, record)
+    return 0 if status in {"ok", "skipped"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- UTC+8 factory day key
- prefer local mp4 ASR with share-URL fallback
- backfill_failed_from_delta; LAST_DEGRADED + fail-visible exits
- Task Scheduler obs docs

## Test plan
- [ ] daily-favorites day key UTC+8
- [ ] missing delta non-zero
- [ ] local ASR fallback

HAI-11 (link only; do not use Closes).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds UTC+8 factory indexing, local-video-first MCP transcription with URL fallback, per-aweme author directories for favorites, and Windows daily automation/backfill tooling.
- Hooks transcript processing and factory-record creation into successful video downloads.
- Adds daily scheduler scripts, merged automation configuration, degraded-state markers, and failed-delta backfill.
- Adds tests and operational documentation for author paths, transcript behavior, and scheduled ingestion.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until media-root preflight and all-skipped backfill runs report failure reliably; the API key should also be removed from subprocess arguments.

The new scheduler can bypass or abort before its documented missing-root handling, and the backfill command returns success despite repairing no failed records; transcript execution also unnecessarily exposes its credential through child-process arguments.

**Files Needing Attention:** scripts/daily-favorites.ps1, tools/backfill_failed_from_delta.py, local_pipeline/mcp_transcript.py

<details open><summary><h3>Security Review</h3></summary>

The MCP worker exposes the configured transcription API key in its process command line. Pass the credential through a restricted child environment or standard input instead.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| local_pipeline/mcp_transcript.py | Adds transcript workers, local-video fallback, sidecars, UTC+8 factory records, and an avoidable API-key exposure through subprocess argv. |
| core/downloader_base.py | Adds the post-download transcript and factory-index hook while preserving download success when transcription fails. |
| core/user_downloader.py | Routes collected works under their original authors, with downstream filename sanitization preventing traversal. |
| scripts/daily-favorites.ps1 | Adds scheduled orchestration and fail-visible state, but creates the factory path before validating the media root. |
| tools/backfill_failed_from_delta.py | Adds targeted failed-row retries, but reports success when all selected repairs are skipped. |
| tools/merge_daily_config.py | Builds the daily automation configuration overlay and enables the intended MCP path. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Scheduler
    participant Daily as daily-favorites.ps1
    participant Downloader
    participant MCP as MCP transcript worker
    participant Factory as _factory JSONL
    participant Ingest as ghaishu ingest
    Scheduler->>Daily: Start daily favorites task
    Daily->>Downloader: Run merged automation config
    Downloader->>MCP: Transcribe local MP4
    alt Local ASR fails
        MCP->>MCP: Retry using share URL
    end
    MCP-->>Downloader: ok / failed / skipped
    Downloader->>Factory: Append manifest and UTC+8 delta row
    Daily->>Factory: Validate today's delta/statuses
    Daily->>Ingest: Project daily delta
    Daily-->>Scheduler: Business-visible exit code
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(daily): ship automation overlay + Do..."](https://github.com/jiji262/douyin-downloader/commit/68ade09a473e59a82007ed1d0023cd6d45240387) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51837750)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->