### PR TITLE
123

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,9 +344,12 @@ Endpoints:
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/v1/download` | Submit `{"url": "..."}`, returns `{job_id, status}` |
+| POST | `/api/v1/resolve` | Resolve one video or gallery into `{aweme_id, title, media_type, urls}` |
 | GET | `/api/v1/jobs/{job_id}` | Get a specific job's status/counts |
 | GET | `/api/v1/jobs` | List recent jobs (TTL + capacity capped) |
 | GET | `/api/v1/health` | Health probe |
+
+`/api/v1/resolve` does not save media files. Returned CDN URLs are short-lived and should be downloaded immediately.
 
 Finished jobs are pruned by TTL (default 24h) and max-jobs (default 500) — in-flight jobs are never pruned. Configure via `server.max_jobs` / `server.job_ttl_seconds`.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -334,9 +334,12 @@ python run.py --serve --serve-port 8000
 | Method | Path | 说明 |
 |--------|------|------|
 | POST | `/api/v1/download` | 提交 `{"url": "..."}`，返回 `{job_id, status}` |
+| POST | `/api/v1/resolve` | 解析单个视频或图集，返回 `{aweme_id, title, media_type, urls}` |
 | GET | `/api/v1/jobs/{job_id}` | 查询指定 job 的状态/计数 |
 | GET | `/api/v1/jobs` | 列出最近的 job（按 TTL + 容量剪裁） |
 | GET | `/api/v1/health` | 健康探针 |
+
+`/api/v1/resolve` 不会保存媒体文件；返回的 CDN URL 有时效，应立即下载。
 
 完成态的 job 会按 TTL（默认 24 小时）+ 最大数量（默认 500）自动剪裁；in-flight 的 job 永不被裁掉。
 可通过 `server.max_jobs` / `server.job_ttl_seconds` 调整。

--- a/server/app.py
+++ b/server/app.py
@@ -20,6 +20,7 @@ from config import ConfigLoader
 from control import QueueManager, RateLimiter, RetryHandler
 from core import DouyinAPIClient, DownloaderFactory, URLParser
 from server.jobs import JobManager
+from server.resolver import MediaResolveError, resolve_media_urls
 from storage import FileManager
 from utils.logger import setup_logger
 from utils.validators import is_short_url, normalize_short_url
@@ -35,6 +36,13 @@ class JobResponse(BaseModel):
     job_id: str
     status: str
     url: str
+
+
+class ResolveResponse(BaseModel):
+    aweme_id: str
+    title: str
+    media_type: str
+    urls: List[str]
 
 
 class _ServerDeps:
@@ -164,6 +172,16 @@ def build_app(config: ConfigLoader) -> FastAPI:
             raise HTTPException(status_code=400, detail="url is required")
         job = await manager.submit(req.url)
         return JobResponse(job_id=job.job_id, status=job.status, url=job.url)
+
+    @app.post("/api/v1/resolve", response_model=ResolveResponse)
+    async def resolve_media(req: DownloadRequest) -> ResolveResponse:
+        if not req.url:
+            raise HTTPException(status_code=400, detail="url is required")
+        try:
+            result = await resolve_media_urls(req.url, deps)
+        except MediaResolveError as exc:
+            raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+        return ResolveResponse(**result)
 
     @app.get("/api/v1/jobs/{job_id}")
     async def get_job(job_id: str) -> Dict[str, Any]:

--- a/server/resolver.py
+++ b/server/resolver.py
@@ -1,0 +1,165 @@
+"""Resolve Douyin work links to short-lived media CDN URLs without saving files."""
+
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import aiohttp
+import httpx
+
+from core import DouyinAPIClient, DownloaderFactory, URLParser
+from utils.logger import setup_logger
+from utils.validators import is_short_url, normalize_short_url
+
+logger = setup_logger("RESTResolver")
+
+
+class MediaResolveError(Exception):
+    def __init__(self, status_code: int, detail: str):
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+def _usable_media_response(status: int, headers: Any) -> bool:
+    if status not in (200, 206):
+        return False
+    content_type = str((headers or {}).get("Content-Type") or "")
+    content_type = content_type.split(";", 1)[0].strip().lower()
+    if not content_type:
+        return True
+    return not (content_type.startswith("text/") or content_type.endswith("/json"))
+
+
+async def _resolve_candidate_url(
+    session: Any,
+    url: str,
+    headers: Dict[str, str],
+    proxy: str,
+) -> Optional[str]:
+    """Probe one candidate with one byte and return the final CDN redirect URL."""
+    probe_headers = {**headers, "Range": "bytes=0-0"}
+    try:
+        async with session.get(
+            url,
+            headers=probe_headers,
+            allow_redirects=True,
+            proxy=proxy or None,
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as response:
+            if _usable_media_response(response.status, response.headers):
+                return str(response.url)
+    except Exception as exc:
+        logger.debug("aiohttp media URL probe failed: %s", exc)
+
+    # Match FileManager's fallback for mirrors that reject aiohttp's TLS fingerprint.
+    try:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(10.0, connect=5.0),
+            proxy=proxy or None,
+            follow_redirects=True,
+        ) as client:
+            async with client.stream("GET", url, headers=probe_headers) as response:
+                if _usable_media_response(response.status_code, response.headers):
+                    return str(response.url)
+    except Exception as exc:
+        logger.debug("httpx media URL probe failed: %s", exc)
+    return None
+
+
+async def _first_reachable_url(
+    session: Any,
+    candidates: Sequence[Tuple[str, Dict[str, str]]],
+    proxy: str,
+) -> Optional[str]:
+    for url, headers in candidates:
+        resolved = await _resolve_candidate_url(session, url, headers, proxy)
+        if resolved:
+            return resolved
+    return None
+
+
+async def resolve_media_urls(url: str, deps: Any) -> Dict[str, Any]:
+    """Resolve one video/gallery link into one URL per actual media asset."""
+    async with DouyinAPIClient(
+        deps.cookie_manager.get_cookies(),
+        proxy=deps.config.get("proxy"),
+    ) as api_client:
+        if is_short_url(url):
+            resolved = await api_client.resolve_short_url(normalize_short_url(url))
+            if not resolved:
+                raise MediaResolveError(422, "Failed to resolve short URL")
+            url = resolved
+
+        parsed = URLParser.parse(url)
+        if not parsed:
+            raise MediaResolveError(422, "Unsupported Douyin URL")
+        if parsed["type"] not in ("video", "gallery"):
+            raise MediaResolveError(422, "Only a single video or gallery URL is supported")
+
+        aweme_id = parsed.get("aweme_id")
+        if not aweme_id:
+            raise MediaResolveError(422, "No aweme_id found in URL")
+
+        await deps.rate_limiter.acquire()
+        aweme_data = await api_client.get_video_detail(str(aweme_id))
+        if not aweme_data:
+            raise MediaResolveError(502, "Failed to fetch Douyin work detail")
+
+        downloader = DownloaderFactory.create(
+            parsed["type"],
+            deps.config,
+            api_client,
+            deps.file_manager,
+            deps.cookie_manager,
+            None,
+            deps.rate_limiter,
+            deps.retry_handler,
+            deps.queue_manager,
+            progress_reporter=None,
+        )
+        if downloader is None:
+            raise MediaResolveError(422, "No resolver for this URL type")
+
+        session = await api_client.get_session()
+        proxy = str(deps.config.get("proxy") or "").strip()
+        media_type = downloader._detect_media_type(aweme_data)
+        urls: List[str] = []
+
+        if media_type == "video":
+            candidates = downloader._build_video_url_candidates(aweme_data)
+            candidates = await downloader._maybe_promote_original_candidate(
+                aweme_data, candidates, session
+            )
+            selected = await _first_reachable_url(session, candidates, proxy)
+            if not selected:
+                raise MediaResolveError(502, "No reachable video URL found")
+            urls.append(selected)
+        elif media_type == "gallery":
+            headers = downloader._download_headers()
+            for index, group in enumerate(
+                downloader._collect_image_url_candidates(aweme_data), start=1
+            ):
+                candidates = [(candidate, headers) for candidate in group]
+                selected = await _first_reachable_url(session, candidates, proxy)
+                if not selected:
+                    raise MediaResolveError(502, f"No reachable URL for gallery image {index}")
+                urls.append(selected)
+
+            for index, candidate in enumerate(
+                downloader._collect_image_live_urls(aweme_data), start=1
+            ):
+                selected = await _first_reachable_url(session, [(candidate, headers)], proxy)
+                if not selected:
+                    raise MediaResolveError(502, f"No reachable URL for live photo {index}")
+                urls.append(selected)
+        else:
+            raise MediaResolveError(422, f"Unsupported media type: {media_type}")
+
+        urls = list(dict.fromkeys(urls))
+        if not urls:
+            raise MediaResolveError(502, "No media URL found")
+        return {
+            "aweme_id": str(aweme_data.get("aweme_id") or aweme_id),
+            "title": str(aweme_data.get("desc") or ""),
+            "media_type": media_type,
+            "urls": urls,
+        }

--- a/tests/test_server_resolver.py
+++ b/tests/test_server_resolver.py
@@ -1,0 +1,220 @@
+"""Resolve-only REST API tests. External Douyin and CDN requests are fully mocked."""
+
+from typing import Any, Dict
+
+import pytest
+
+try:
+    from fastapi.testclient import TestClient  # type: ignore
+except ImportError:  # pragma: no cover
+    pytest.skip("fastapi not installed", allow_module_level=True)
+
+from config import ConfigLoader
+from server import resolver
+from server.app import build_app
+
+
+class _FakeResponse:
+    def __init__(self, url: str, status: int = 206, content_type: str = "video/mp4"):
+        self.url = url
+        self.status = status
+        self.headers = {"Content-Type": content_type}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, final_url: str):
+        self.final_url = final_url
+        self.requests = []
+
+    def get(self, url: str, **kwargs):
+        self.requests.append((url, kwargs))
+        return _FakeResponse(self.final_url)
+
+
+class _FakeAPIClient:
+    detail: Dict[str, Any] = {}
+    final_work_url = "https://www.douyin.com/video/1234567890123456789"
+    session = _FakeSession("https://v3-web.douyinvod.com/final.mp4")
+
+    def __init__(self, cookies, proxy=None):
+        self.cookies = cookies
+        self.proxy = proxy
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    async def resolve_short_url(self, url: str):
+        return self.final_work_url
+
+    async def get_video_detail(self, aweme_id: str):
+        return self.detail
+
+    async def get_session(self):
+        return self.session
+
+
+class _FakeVideoDownloader:
+    def _detect_media_type(self, aweme_data):
+        return "video"
+
+    def _build_video_url_candidates(self, aweme_data):
+        return [("https://www.douyin.com/aweme/v1/play/?signed=1", {"User-Agent": "ua"})]
+
+    async def _maybe_promote_original_candidate(self, aweme_data, candidates, session):
+        return candidates
+
+
+class _FakeGalleryDownloader:
+    def _detect_media_type(self, aweme_data):
+        return "gallery"
+
+    def _download_headers(self):
+        return {"Referer": "https://www.douyin.com/"}
+
+    def _collect_image_url_candidates(self, aweme_data):
+        return [["https://img/one-a", "https://img/one-b"], ["https://img/two"]]
+
+    def _collect_image_live_urls(self, aweme_data):
+        return ["https://video/live"]
+
+
+def _build_deps(tmp_path):
+    config = ConfigLoader(None)
+    config.update(path=str(tmp_path), rate_limit=1000)
+    return build_app(config).state.deps
+
+
+@pytest.mark.asyncio
+async def test_candidate_probe_returns_final_redirect_without_reading_body():
+    session = _FakeSession("https://v3-web.douyinvod.com/final.mp4")
+
+    result = await resolver._resolve_candidate_url(
+        session,
+        "https://www.douyin.com/aweme/v1/play/?signed=1",
+        {"User-Agent": "signed-agent"},
+        "",
+    )
+
+    assert result == "https://v3-web.douyinvod.com/final.mp4"
+    _, kwargs = session.requests[0]
+    assert kwargs["headers"]["Range"] == "bytes=0-0"
+    assert kwargs["headers"]["User-Agent"] == "signed-agent"
+    assert kwargs["allow_redirects"] is True
+
+
+@pytest.mark.asyncio
+async def test_resolve_video_returns_one_final_cdn_url_without_files(tmp_path, monkeypatch):
+    _FakeAPIClient.detail = {
+        "aweme_id": "1234567890123456789",
+        "desc": "测试视频",
+        "video": {},
+    }
+    _FakeAPIClient.session = _FakeSession("https://v3-web.douyinvod.com/final.mp4")
+    monkeypatch.setattr(resolver, "DouyinAPIClient", _FakeAPIClient)
+    monkeypatch.setattr(
+        resolver.DownloaderFactory,
+        "create",
+        lambda *args, **kwargs: _FakeVideoDownloader(),
+    )
+
+    result = await resolver.resolve_media_urls("https://v.douyin.com/short/", _build_deps(tmp_path))
+
+    assert result == {
+        "aweme_id": "1234567890123456789",
+        "title": "测试视频",
+        "media_type": "video",
+        "urls": ["https://v3-web.douyinvod.com/final.mp4"],
+    }
+    assert list(tmp_path.rglob("*")) == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_gallery_returns_one_url_per_asset(tmp_path, monkeypatch):
+    _FakeAPIClient.detail = {
+        "aweme_id": "1234567890123456789",
+        "desc": "测试图集",
+        "image_post_info": {"images": [{}]},
+    }
+    monkeypatch.setattr(resolver, "DouyinAPIClient", _FakeAPIClient)
+    monkeypatch.setattr(
+        resolver.DownloaderFactory,
+        "create",
+        lambda *args, **kwargs: _FakeGalleryDownloader(),
+    )
+
+    async def fake_resolve(session, url, headers, proxy):
+        return {
+            "https://img/one-a": None,
+            "https://img/one-b": "https://cdn/image-1.jpeg",
+            "https://img/two": "https://cdn/image-2.jpeg",
+            "https://video/live": "https://cdn/live.mp4",
+        }[url]
+
+    monkeypatch.setattr(resolver, "_resolve_candidate_url", fake_resolve)
+    result = await resolver.resolve_media_urls(
+        "https://www.douyin.com/note/1234567890123456789", _build_deps(tmp_path)
+    )
+
+    assert result["media_type"] == "gallery"
+    assert result["urls"] == [
+        "https://cdn/image-1.jpeg",
+        "https://cdn/image-2.jpeg",
+        "https://cdn/live.mp4",
+    ]
+    assert list(tmp_path.rglob("*")) == []
+
+
+def test_resolve_endpoint_returns_media_urls(tmp_path, monkeypatch):
+    config = ConfigLoader(None)
+    config.update(path=str(tmp_path))
+    app = build_app(config)
+
+    async def fake_resolve(url, deps):
+        assert url == "https://v.douyin.com/example/"
+        return {
+            "aweme_id": "123",
+            "title": "快捷指令测试",
+            "media_type": "video",
+            "urls": ["https://cdn/video.mp4"],
+        }
+
+    monkeypatch.setattr("server.app.resolve_media_urls", fake_resolve)
+    with TestClient(app) as client:
+        response = client.post("/api/v1/resolve", json={"url": "https://v.douyin.com/example/"})
+
+    assert response.status_code == 200
+    assert response.json()["urls"] == ["https://cdn/video.mp4"]
+
+
+def test_resolve_endpoint_maps_domain_error(tmp_path, monkeypatch):
+    config = ConfigLoader(None)
+    config.update(path=str(tmp_path))
+    app = build_app(config)
+
+    async def fail_resolve(url, deps):
+        raise resolver.MediaResolveError(422, "Only a single video or gallery URL is supported")
+
+    monkeypatch.setattr("server.app.resolve_media_urls", fail_resolve)
+    with TestClient(app) as client:
+        response = client.post("/api/v1/resolve", json={"url": "https://www.douyin.com/user/abc"})
+
+    assert response.status_code == 422
+    assert "single video or gallery" in response.json()["detail"]
+
+
+def test_resolve_endpoint_rejects_empty_url(tmp_path):
+    config = ConfigLoader(None)
+    config.update(path=str(tmp_path))
+    app = build_app(config)
+    with TestClient(app) as client:
+        response = client.post("/api/v1/resolve", json={"url": ""})
+    assert response.status_code == 400


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a resolve-only REST endpoint that fetches a single Douyin work and returns short-lived video or gallery CDN URLs without saving files.

- Adds `/api/v1/resolve`, its response model, and bilingual endpoint documentation.
- Introduces URL parsing, work-detail retrieval, media candidate probing, redirect resolution, and gallery handling.
- Adds mocked resolver and endpoint tests for video, gallery, validation, and domain-error behavior.

<h3>Confidence Score: 4/5</h3>

The authentication failure path should be translated before merging; gallery deduplication is also a non-blocking contract concern.

An expired or unauthenticated Douyin session can raise `LoginRequiredError` through the new resolve path and produce an unhandled server error, while final URL deduplication can collapse separate gallery assets.

**Files Needing Attention:** server/resolver.py and server/app.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| server/resolver.py | Implements resolution and CDN probing, but authentication exceptions can escape and gallery-wide URL deduplication can lose asset cardinality. |
| server/app.py | Adds the resolve route and response model, with error translation limited to resolver-domain exceptions. |
| tests/test_server_resolver.py | Covers primary video, gallery, redirect, validation, and mapped-error flows but not login-required failures or duplicate final URLs. |
| README.md | Documents the new endpoint and the short-lived nature of returned CDN URLs. |
| README.zh-CN.md | Adds matching Chinese documentation for the resolve endpoint. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as POST /api/v1/resolve
    participant Resolver
    participant Douyin as Douyin API
    participant CDN
    Client->>API: Submit work URL
    API->>Resolver: resolve_media_urls(url, deps)
    Resolver->>Douyin: Resolve short URL and fetch work detail
    Douyin-->>Resolver: Work metadata
    loop Media candidates
        Resolver->>CDN: "GET Range bytes=0-0"
        CDN-->>Resolver: Redirect and media response
    end
    Resolver-->>API: aweme_id, title, media_type, urls
    API-->>Client: ResolveResponse
```
</details>

<sub>Reviews (1): Last reviewed commit: ["123"](https://github.com/jiji262/douyin-downloader/commit/a8e82c3de9a46afeb9ed4016a11db6088beb30d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54673430)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->